### PR TITLE
Switch to asynchronous IO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - pip install codecov tox
 
 script:
-  - tox -e py
+  - tox -e py35,lint
 
 after_success:
   - codecov --env TRAVIS_PYTHON_VERSION

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ upload: bin/python setup.py README
 test: bin/tox
 	@bin/tox
 
+lint: bin/tox
+	@bin/tox -e lint
+
 clean:
 	$(RM) -r bin build dist include lib local share
 	find . -name '*.py[co]' -print0 | xargs -r0 $(RM) -r
@@ -44,4 +47,4 @@ bin/mkdocs: bin/pip
 
 # ---
 
-.PHONY: develop dist docs test clean
+.PHONY: develop dist docs test lint clean

--- a/maas/client/bones/__init__.py
+++ b/maas/client/bones/__init__.py
@@ -16,10 +16,10 @@ from collections import (
 from http import HTTPStatus
 import json
 import re
-import ssl
 from urllib.parse import urljoin
 
-import httplib2
+import aiohttp
+import aiohttp.errors
 
 from .. import utils
 from ..utils import profiles
@@ -35,29 +35,26 @@ class SessionAPI:
     """Represents an API session with a remote MAAS installation."""
 
     @classmethod
-    def fromURL(cls, url, *, credentials=None, insecure=False):
+    async def fromURL(
+            cls, url, *, credentials=None, insecure=False):
         """Return a `SessionAPI` for a given MAAS instance."""
         url_describe = urljoin(url, "describe/")
-        http = httplib2.Http(disable_ssl_certificate_validation=insecure)
-
-        try:
-            response, content = http.request(url_describe, "GET")
-        except ssl.SSLError:
-            raise SessionError("Certificate verification failed.")
-
-        if response.status != HTTPStatus.OK:
-            raise SessionError(
-                "{0} -> {1.status} {1.reason}".format(url, response))
-        elif response["content-type"] != "application/json":
-            raise SessionError(
-                "Expected application/json, got: %(content-type)s"
-                % response)
-        else:
-            # MAAS will only ever produce JSON as ASCII or UTF-8.
-            description = json.loads(content.decode('utf-8'))
-            session = cls(description, credentials)
-            session.insecure = insecure
-            return session
+        connector = aiohttp.TCPConnector(verify_ssl=(not insecure))
+        session = aiohttp.ClientSession(connector=connector)
+        async with session, session.get(url_describe) as response:
+            if response.status != HTTPStatus.OK:
+                raise SessionError(
+                    "{0} -> {1.status} {1.reason}".format(
+                        url, response))
+            elif response.content_type != "application/json":
+                raise SessionError(
+                    "Expected application/json, got: %s"
+                    % response.content_type)
+            else:
+                description = await response.json()
+                session = cls(description, credentials)
+                session.insecure = insecure
+                return session
 
     @classmethod
     def fromProfile(cls, profile):
@@ -436,41 +433,53 @@ class CallAPI:
 
         return uri, body, headers
 
-    def dispatch(self, uri, body, headers):
+    async def dispatch(self, uri, body, headers):
         """Dispatch the call via HTTP.
 
         This is used by `call` and can be overridden to use a different HTTP
         library.
         """
         insecure = self.action.handler.session.insecure
-        http = httplib2.Http(disable_ssl_certificate_validation=insecure)
-        response, content = http.request(
-            uri, self.action.method, body=body, headers=headers)
+        connector = aiohttp.TCPConnector(verify_ssl=(not insecure))
+        session = aiohttp.ClientSession(connector=connector)
+        async with session:
+            response = await session.request(
+                self.action.method, uri, data=body, headers=headers)
+            async with response:
+                # Fetch the raw body content.
+                content = await response.read()
 
-        # Debug output.
-        if self.action.handler.session.debug:
-            print(response)
+                # Debug output.
+                if self.action.handler.session.debug:
+                    print(response)
 
-        # 2xx status codes are all okay.
-        if response.status // 100 != 2:
-            request = {
-                "body": body,
-                "headers": headers,
-                "method": self.action.method,
-                "uri": uri,
-            }
-            raise CallError(request, response, content, self)
+                # 2xx status codes are all okay.
+                if response.status // 100 != 2:
+                    request = {
+                        "body": body,
+                        "headers": headers,
+                        "method": self.action.method,
+                        "uri": uri,
+                    }
+                    raise CallError(request, response, content, self)
 
-        # Decode from JSON if that's what it's declared as.
-        content_type = utils.get_response_content_type(response)
-        if content_type is None:
-            data = content
-        elif content_type.endswith('/json'):
-            data = json.loads(content.decode("utf-8"))  # Assume it's UTF-8.
-        else:
-            data = content
+                # Decode from JSON if that's what it's declared as.
+                if response.content_type is None:
+                    data = await response.read()
+                elif response.content_type.endswith('/json'):
+                    data = await response.json()
+                else:
+                    data = await response.read()
 
-        return CallResult(response, content, data)
+                if response.content_type is None:
+                    data = content
+                elif response.content_type.endswith('/json'):
+                    # JSON should always be UTF-8.
+                    data = json.loads(content.decode("utf-8"))
+                else:
+                    data = content
+
+                return CallResult(response, content, data)
 
     def __repr__(self):
         return "<Call %s @%s>" % (self.action.fullname, self.uri)

--- a/maas/client/testing.py
+++ b/maas/client/testing.py
@@ -12,6 +12,7 @@ __all__ = [
     "TestCase",
 ]
 
+import asyncio
 import doctest
 from functools import partial
 from itertools import (
@@ -128,6 +129,12 @@ class WithScenarios(testscenarios.WithScenarios):
 
 
 class TestCase(WithScenarios, testcase.TestCase):
+
+    def setUp(self):
+        super(TestCase, self).setUp()
+        self.loop = asyncio.new_event_loop()
+        self.addCleanup(self.loop.close)
+        asyncio.set_event_loop(self.loop)
 
     def make_dir(self):
         """Create a temporary directory.

--- a/maas/client/utils/__init__.py
+++ b/maas/client/utils/__init__.py
@@ -3,7 +3,6 @@
 __all__ = [
     "api_url",
     "get_all_subclasses",
-    "get_response_content_type",
     "parse_docstring",
     "prepare_payload",
     "retries",
@@ -13,7 +12,6 @@ __all__ = [
 ]
 
 from collections import Iterable
-from email.message import Message
 from functools import (
     lru_cache,
     partial,
@@ -65,26 +63,6 @@ def urlencode(data):
     return "&".join(
         "%s=%s" % (dec(name), dec(value))
         for name, value in data)
-
-
-def get_response_content_type(response):
-    """Returns the response's content-type, without parameters.
-
-    If the content-type was not set in the response, returns `None`.
-
-    :type response: :class:`httplib2.Response`
-    """
-    try:
-        content_type = response["content-type"]
-    except KeyError:
-        return None
-    else:
-        # It seems odd to create a Message instance here, but at the time of
-        # writing it's the only place that has the smarts to correctly deal
-        # with a Content-Type that contains a charset (or other parameters).
-        message = Message()
-        message.set_type(content_type)
-        return message.get_content_type()
 
 
 def prepare_payload(op, method, uri, data):

--- a/maas/client/utils/async.py
+++ b/maas/client/utils/async.py
@@ -1,0 +1,60 @@
+"""Asynchronous helpers, for use with `asyncio`."""
+
+__all__ = [
+    "asynchronous",
+    "Asynchronous",
+]
+
+from functools import wraps
+
+
+def asynchronous(func):
+    """Return `func` in a "smart" asynchronous-aware wrapper.
+
+    If `func` is called within the event-loop — i.e. when it is running — this
+    returns the result of `func` without alteration. However, when called from
+    outside of the event-loop, and the result is awaitable, the result will be
+    passed though the current event-loop's `run_until_complete` method.
+
+    In other words, this automatically blocks when calling an asynchronous
+    function from outside of the event-loop, and so makes interactive use of
+    these APIs far more intuitive.
+    """
+    from asyncio import get_event_loop
+    from inspect import isawaitable
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        eventloop = get_event_loop()
+        result = func(*args, **kwargs)
+        if eventloop.is_running():
+            return result
+        elif isawaitable(result):
+            return eventloop.run_until_complete(result)
+        else:
+            return result
+
+    return wrapper
+
+
+class Asynchronous(type):
+    """Metaclass that wraps callable attributes with `asynchronous`.
+
+    Use this to create classes instances of which work naturally when working
+    with them interactively.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        attrs.setdefault("__slots__", ())
+        attrs = {name: _maybe_wrap(value) for name, value in attrs.items()}
+        return super(Asynchronous, cls).__new__(cls, name, bases, attrs)
+
+
+def _maybe_wrap(attribute):
+    """Helper for `Asynchronous`."""
+    if callable(attribute):
+        return asynchronous(attribute)
+    elif isinstance(attribute, (classmethod, staticmethod)):
+        return attribute.__class__(asynchronous(attribute.__func__))
+    else:
+        return attribute

--- a/maas/client/utils/tests/test_async.py
+++ b/maas/client/utils/tests/test_async.py
@@ -1,0 +1,92 @@
+"""Tests for asynchronous helpers."""
+
+__all__ = []
+
+import asyncio
+from inspect import isawaitable
+
+from testtools.matchers import (
+    Equals,
+    Is,
+    MatchesPredicate,
+)
+
+from .. import async
+from ...testing import TestCase
+
+
+IsAwaitable = MatchesPredicate(isawaitable, "%s is not awaitable")
+
+
+class TestAsynchronousWrapper(TestCase):
+    """Tests for `asynchronous`."""
+
+    def test_returns_plain_result_unaltered_when_loop_not_running(self):
+        token = object()
+        func = async.asynchronous(lambda: token)
+        self.assertThat(func(), Is(token))
+
+    def test_returns_plain_result_unaltered_when_loop_running(self):
+        token = object()
+        func = async.asynchronous(lambda: token)
+
+        async def within_event_loop():
+            loop = asyncio.get_event_loop()
+            self.assertTrue(loop.is_running())
+            return func()
+
+        self.assertThat(
+            self.loop.run_until_complete(within_event_loop()),
+            Is(token))
+
+    def test_blocks_on_awaitable_result_when_loop_not_running(self):
+        token = asyncio.sleep(0.0)
+        func = async.asynchronous(lambda: token)
+        self.assertThat(func(), Is(None))
+
+    def test_returns_awaitable_result_unaltered_when_loop_running(self):
+        token = asyncio.sleep(0.0)
+        func = async.asynchronous(lambda: token)
+
+        async def within_event_loop():
+            loop = asyncio.get_event_loop()
+            self.assertTrue(loop.is_running())
+            return func()
+
+        result = self.loop.run_until_complete(within_event_loop())
+        self.assertThat(result, Is(token))
+        self.assertThat(result, IsAwaitable)
+        result = self.loop.run_until_complete(result)
+        self.assertThat(result, Is(None))
+
+
+class TestAsynchronousType(TestCase):
+    """Tests for `Asynchronous`."""
+
+    def test_callable_attributes_are_wrapped(self):
+        # `Asynchronous` groks class- and static-methods.
+
+        class Class(metaclass=async.Asynchronous):
+
+            attribute = 123
+
+            def imethod(self):
+                return self, "instancemethod"
+
+            @classmethod
+            def cmethod(cls):
+                return cls, "classmethod"
+
+            @staticmethod
+            def smethod():
+                return None, "staticmethod"
+
+        self.assertThat(Class.attribute, Equals(123))
+        self.assertThat(Class.smethod(), Equals((None, "staticmethod")))
+        self.assertThat(Class.cmethod(), Equals((Class, "classmethod")))
+
+        inst = Class()
+        self.assertThat(inst.attribute, Equals(123))
+        self.assertThat(inst.smethod(), Equals((None, "staticmethod")))
+        self.assertThat(inst.cmethod(), Equals((Class, "classmethod")))
+        self.assertThat(inst.imethod(), Equals((inst, "instancemethod")))

--- a/maas/client/utils/tests/test_auth.py
+++ b/maas/client/utils/tests/test_auth.py
@@ -2,7 +2,6 @@
 
 __all__ = []
 
-from argparse import Namespace
 import sys
 from unittest.mock import (
     ANY,
@@ -10,11 +9,11 @@ from unittest.mock import (
 )
 
 from .. import auth
-from ..creds import Credentials
 from ...testing import (
     make_name,
     TestCase,
 )
+from ..creds import Credentials
 
 
 def make_credentials():

--- a/maas/client/utils/tests/test_connect.py
+++ b/maas/client/utils/tests/test_connect.py
@@ -15,11 +15,11 @@ from .. import (
     connect,
     profiles,
 )
-from .test_auth import make_credentials
 from ...testing import (
     make_name_without_spaces,
     TestCase,
 )
+from .test_auth import make_credentials
 
 
 class TestConnect(TestCase):

--- a/maas/client/utils/tests/test_creds.py
+++ b/maas/client/utils/tests/test_creds.py
@@ -4,8 +4,8 @@ __all__ = []
 
 from testtools.matchers import IsInstance
 
-from ..creds import Credentials
 from ...testing import TestCase
+from ..creds import Credentials
 
 
 class TestCredentials(TestCase):

--- a/maas/client/utils/tests/test_login.py
+++ b/maas/client/utils/tests/test_login.py
@@ -15,11 +15,11 @@ from .. import (
     login,
     profiles,
 )
-from .test_auth import make_credentials
 from ...testing import (
     make_name_without_spaces,
     TestCase,
 )
+from .test_auth import make_credentials
 
 
 class TestLogin(TestCase):

--- a/maas/client/utils/tests/test_multipart.py
+++ b/maas/client/utils/tests/test_multipart.py
@@ -14,13 +14,13 @@ from testtools.matchers import (
     StartsWith,
 )
 
-from ..multipart import (
-    encode_multipart_data,
-    get_content_type,
-)
 from ...testing import (
     make_string,
     TestCase,
+)
+from ..multipart import (
+    encode_multipart_data,
+    get_content_type,
 )
 
 # Django, sigh, needs this.

--- a/maas/client/utils/tests/test_profiles.py
+++ b/maas/client/utils/tests/test_profiles.py
@@ -14,17 +14,17 @@ from testtools.matchers import (
 )
 from twisted.python.filepath import FilePath
 
-from .test_auth import make_credentials
 from .. import profiles
+from ...testing import (
+    make_name_without_spaces,
+    TestCase,
+)
 from ..profiles import (
     Profile,
     ProfileNotFound,
     ProfileStore,
 )
-from ...testing import (
-    make_name_without_spaces,
-    TestCase,
-)
+from .test_auth import make_credentials
 
 
 def make_profile():

--- a/maas/client/viscera/__init__.py
+++ b/maas/client/viscera/__init__.py
@@ -32,15 +32,17 @@ from itertools import (
     chain,
     starmap,
 )
-import pytz
 from types import MethodType
 from typing import Optional
+
+import pytz
 
 from .. import bones
 from ..utils import (
     get_all_subclasses,
     vars_class,
 )
+from ..utils.async import Asynchronous
 
 
 undefined = object()
@@ -138,7 +140,7 @@ class OriginObjectRef:
         raise AttributeError()
 
 
-class ObjectType(type):
+class ObjectType(Asynchronous, metaclass=Asynchronous):
 
     def __dir__(cls):
         return dir_class(cls)

--- a/maas/client/viscera/account.py
+++ b/maas/client/viscera/account.py
@@ -16,13 +16,13 @@ class AccountType(ObjectType):
     """Metaclass for `Account`."""
 
     @typed
-    def create_credentials(cls) -> Credentials:
-        data = cls._handler.create_authorisation_token()
+    async def create_credentials(cls) -> Credentials:
+        data = await cls._handler.create_authorisation_token()
         return Credentials(**data)
 
     @typed
-    def delete_credentials(cls, credentials: Credentials) -> None:
-        cls._handler.delete_authorisation_token(
+    async def delete_credentials(cls, credentials: Credentials) -> None:
+        await cls._handler.delete_authorisation_token(
             token_key=credentials.token_key)
 
 

--- a/maas/client/viscera/boot_resources.py
+++ b/maas/client/viscera/boot_resources.py
@@ -193,7 +193,7 @@ class BootResourcesType(ObjectType):
                 length = len(buf)
                 if length > 0:
                     uploaded_size += length
-                    await cls._put_chunk(upload_uri, buf)
+                    await cls._put_chunk(session, upload_uri, buf)
                     if progress_callback is not None:
                         progress_callback(uploaded_size / rfile.size)
                 if length != chunk_size:
@@ -214,9 +214,10 @@ class BootResourcesType(ObjectType):
             utils.sign(upload_uri, headers, credentials)
 
         # Perform upload of chunk.
-        response, content = await session.put(
+        response = await session.put(
             upload_uri, data=buf, headers=headers)
         if response.status != 200:
+            content = await response.read()
             request = {
                 "body": buf,
                 "headers": headers,

--- a/maas/client/viscera/boot_sources.py
+++ b/maas/client/viscera/boot_sources.py
@@ -46,9 +46,9 @@ class BootSources(ObjectSet, metaclass=BootSourcesType):
 
 class BootSourceType(ObjectType):
 
-    def read(cls, id):
+    async def read(cls, id):
         """Get `BootSource` by `id`."""
-        data = cls._handler.read(id=id)
+        data = await cls._handler.read(id=id)
         return cls(data)
 
 

--- a/maas/client/viscera/boot_sources.py
+++ b/maas/client/viscera/boot_sources.py
@@ -7,7 +7,6 @@ __all__ = [
 
 from . import (
     check,
-    check_optional,
     Object,
     ObjectField,
     ObjectSet,
@@ -19,10 +18,7 @@ from . import (
 class BootSourcesType(ObjectType):
     """Metaclass for `BootSources`."""
 
-    def __iter__(cls):
-        return map(cls._object, cls._handler.read())
-
-    def create(cls, url, *, keyring_filename=None, keyring_data=None):
+    async def create(cls, url, *, keyring_filename=None, keyring_data=None):
         """Create a new `BootSource`."""
         if (not url.endswith(".json") and
                 keyring_filename is None and
@@ -30,7 +26,7 @@ class BootSourcesType(ObjectType):
             raise ValueError(
                 "Either keyring_filename and keyring_data must be set when "
                 "providing a signed source.")
-        data = cls._handler.create(
+        data = await cls._handler.create(
             url=url,
             keyring_filename=(
                 "" if keyring_filename is None else keyring_filename),
@@ -38,14 +34,14 @@ class BootSourcesType(ObjectType):
                 "" if keyring_data is None else keyring_data))
         return cls._object(data)
 
+    async def read(cls):
+        """Get list of `BootSource`'s."""
+        data = await cls._handler.read()
+        return cls(map(cls._object, data))
+
 
 class BootSources(ObjectSet, metaclass=BootSourcesType):
     """The set of boot sources."""
-
-    @classmethod
-    def read(cls):
-        """Get list of `BootSource`'s."""
-        return cls(cls)
 
 
 class BootSourceType(ObjectType):
@@ -76,6 +72,6 @@ class BootSource(Object, metaclass=BootSourceType):
         return super(BootSource, self).__repr__(
             fields={"url", "keyring_filename", "keyring_data"})
 
-    def delete(self):
+    async def delete(self):
         """Delete boot source."""
-        self._handler.delete(id=self.id)
+        await self._handler.delete(id=self.id)

--- a/maas/client/viscera/controllers.py
+++ b/maas/client/viscera/controllers.py
@@ -5,11 +5,7 @@ __all__ = [
     "RackControllers",
 ]
 
-import base64
-from typing import (
-    List,
-    Union,
-)
+from typing import List
 
 from . import (
     check,
@@ -25,11 +21,9 @@ from . import (
 class RackControllersType(ObjectType):
     """Metaclass for `RackControllers`."""
 
-    def __iter__(cls):
-        return map(cls._object, cls._handler.read())
-
-    def read(cls):
-        return cls(cls)
+    async def read(cls):
+        data = await cls._handler.read()
+        return cls(map(cls._object, data))
 
 
 class RackControllerNotFound(Exception):
@@ -42,8 +36,8 @@ class RackControllers(ObjectSet, metaclass=RackControllersType):
 
 class RackControllerType(ObjectType):
 
-    def read(cls, system_id):
-        data = cls._handler.read(system_id=system_id)
+    async def read(cls, system_id):
+        data = await cls._handler.read(system_id=system_id)
         return cls(data)
 
 

--- a/maas/client/viscera/devices.py
+++ b/maas/client/viscera/devices.py
@@ -20,11 +20,9 @@ from . import (
 class DevicesType(ObjectType):
     """Metaclass for `Devices`."""
 
-    def __iter__(cls):
-        return map(cls._object, cls._handler.read())
-
-    def read(cls):
-        return cls(cls)
+    async def read(cls):
+        data = await cls._handler.read()
+        return cls(map(cls._object, data))
 
 
 class DeviceNotFound(Exception):

--- a/maas/client/viscera/events.py
+++ b/maas/client/viscera/events.py
@@ -25,6 +25,7 @@ from . import (
     ObjectSet,
     ObjectType,
 )
+from ..utils.async import is_loop_running
 from ..utils.typecheck import typed
 
 #
@@ -86,7 +87,7 @@ class EventsType(ObjectType):
     Level = Level
 
     @typed
-    def query(
+    async def query(
             cls, *,
             hostnames: Iterable[str]=None,
             domains: Iterable[str]=None,
@@ -127,7 +128,7 @@ class EventsType(ObjectType):
         if limit is not None:
             params["limit"] = ["{:d}".format(limit)]
 
-        data = cls._handler.query(**params)
+        data = await cls._handler.query(**params)
         return cls(data)
 
 
@@ -148,15 +149,15 @@ class Events(ObjectSet, metaclass=EventsType):
         self._next_uri = eventmap["next_uri"]
 
     @classmethod
-    def _fetch(cls, uri, count):
+    async def _fetch(cls, uri, count):
         query = urlparse(uri).query
         params = parse_qs(query, errors="strict")
         if count is not None:
             params["limit"] = ["{:d}".format(count)]
-        data = cls._handler.query(**params)
+        data = await cls._handler.query(**params)
         return cls(data)
 
-    def prev(self, count=None):
+    async def prev(self, count=None):
         """Load the previous (older) page/batch of events.
 
         :param count: A limit on the number of events to fetch. By default the
@@ -167,7 +168,7 @@ class Events(ObjectSet, metaclass=EventsType):
         else:
             return self._fetch(self._prev_uri, count)
 
-    def next(self, count=None):
+    async def next(self, count=None):
         """Load the next (newer) page/batch of events.
 
         :param count: A limit on the number of events to fetch. By default the
@@ -178,25 +179,93 @@ class Events(ObjectSet, metaclass=EventsType):
         else:
             return self._fetch(self._next_uri, count)
 
-    def backwards(self):
+    async def backwards(self):
         """Iterate continuously through events, backwards.
+
+        Note: this returns an *asynchronous* iterator.
 
         This will load new pages/batches of events on demand.
         """
+        if is_loop_running():
+            return EventsAsyncIteratorBackwards(self)
+        else:
+            return self._backwards_sync()
+
+    def _backwards_sync(self):
         current = self
         while len(current) != 0:
             yield from current
+            if is_loop_running():
+                raise RuntimeError(
+                    "Cannot iterate synchronously while "
+                    "event-loop is running.")
             current = current.prev()
 
-    def forwards(self):
+    async def forwards(self):
         """Iterate continuously through events, forwards.
+
+        Note: this returns an *asynchronous* iterator.
 
         This will load new pages/batches of events on demand.
         """
+        if is_loop_running():
+            return EventsAsyncIteratorForwards(self)
+        else:
+            return self._forwards_sync()
+
+    def _forwards_sync(self):
         current = self
         while len(current) != 0:
             yield from reversed(current)
+            if is_loop_running():
+                raise RuntimeError(
+                    "Cannot iterate synchronously while "
+                    "event-loop is running.")
             current = current.next()
+
+
+class EventsAsyncIteratorBackwards:
+
+    def __init__(self, current):
+        super(EventsAsyncIteratorBackwards, self).__init__()
+        self._current_iter = iter(current)
+        self._current = current
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._current_iter)
+        except StopIteration:
+            self._current = await self._current.prev()
+            self._current_iter = iter(self._current)
+            if len(self._current) == 0:
+                raise StopAsyncIteration()
+            else:
+                return next(self._current_iter)
+
+
+class EventsAsyncIteratorForwards:
+
+    def __init__(self, current):
+        super(EventsAsyncIteratorForwards, self).__init__()
+        self._current_iter = reversed(current)
+        self._current = current
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._current_iter)
+        except StopIteration:
+            self._current = await self._current.next()
+            self._current_iter = reversed(self._current)
+            if len(self._current) == 0:
+                raise StopAsyncIteration()
+            else:
+                return next(self._current_iter)
 
 
 def truncate(length, text):  # TODO: Move into utils.

--- a/maas/client/viscera/events.py
+++ b/maas/client/viscera/events.py
@@ -179,7 +179,7 @@ class Events(ObjectSet, metaclass=EventsType):
         else:
             return self._fetch(self._next_uri, count)
 
-    async def backwards(self):
+    def backwards(self):
         """Iterate continuously through events, backwards.
 
         Note: this returns an *asynchronous* iterator.
@@ -201,7 +201,7 @@ class Events(ObjectSet, metaclass=EventsType):
                     "event-loop is running.")
             current = current.prev()
 
-    async def forwards(self):
+    def forwards(self):
         """Iterate continuously through events, forwards.
 
         Note: this returns an *asynchronous* iterator.

--- a/maas/client/viscera/files.py
+++ b/maas/client/viscera/files.py
@@ -17,11 +17,9 @@ from . import (
 class FilesType(ObjectType):
     """Metaclass for `Files`."""
 
-    def __iter__(cls):
-        return map(cls._object, cls._handler.read())
-
-    def read(cls):
-        return cls(cls)
+    async def read(cls):
+        data = await cls._handler.read()
+        return map(cls._object, data)
 
 
 class Files(ObjectSet, metaclass=FilesType):

--- a/maas/client/viscera/maas.py
+++ b/maas/client/viscera/maas.py
@@ -45,75 +45,75 @@ class MAASType(ObjectType):
     """Metaclass for `MAAS`."""
 
     @typed
-    def get_name(cls) -> str:
+    async def get_name(cls) -> str:
         """The name of the MAAS instance."""
-        return cls.get_config("maas_name")
+        return await cls.get_config("maas_name")
 
     @typed
-    def set_name(cls, name: str):
+    async def set_name(cls, name: str):
         """See `get_name`."""
-        return cls.set_config("maas_name", name)
+        return await cls.set_config("maas_name", name)
 
     @typed
-    def get_main_archive(cls) -> str:
+    async def get_main_archive(cls) -> str:
         """Main archive URL.
 
         Archive used by nodes to retrieve packages for Intel architectures,
         e.g. http://archive.ubuntu.com/ubuntu.
         """
-        return cls.get_config("main_archive")
+        return await cls.get_config("main_archive")
 
     @typed
-    def set_main_archive(cls, url: str):
+    async def set_main_archive(cls, url: str):
         """See `get_main_archive`."""
-        cls.set_config("main_archive", url)
+        await cls.set_config("main_archive", url)
 
     @typed
-    def get_ports_archive(cls) -> str:
+    async def get_ports_archive(cls) -> str:
         """Ports archive.
 
         Archive used by nodes to retrieve packages for non-Intel
         architectures. E.g. http://ports.ubuntu.com/ubuntu-ports.
         """
-        return cls.get_config("ports_archive")
+        return await cls.get_config("ports_archive")
 
     @typed
-    def set_ports_archive(cls, series: str):
+    async def set_ports_archive(cls, series: str):
         """See `get_ports_archive`."""
-        cls.set_config("ports_archive", series)
+        await cls.set_config("ports_archive", series)
 
     @typed
-    def get_default_os(cls) -> str:
+    async def get_default_os(cls) -> str:
         """Default OS used for deployment."""
-        return cls.get_config("default_osystem")
+        return await cls.get_config("default_osystem")
 
     @typed
-    def set_default_os(cls, series: str):
+    async def set_default_os(cls, series: str):
         """See `get_default_os`."""
-        cls.set_config("default_osystem", series)
+        await cls.set_config("default_osystem", series)
 
     @typed
-    def get_default_distro_series(cls) -> str:
+    async def get_default_distro_series(cls) -> str:
         """Default OS release used for deployment."""
-        return cls.get_config("default_distro_series")
+        return await cls.get_config("default_distro_series")
 
     @typed
-    def set_default_distro_series(cls, series: str):
+    async def set_default_distro_series(cls, series: str):
         """See `get_default_distro_series`."""
-        cls.set_config("default_distro_series", series)
+        await cls.set_config("default_distro_series", series)
 
     @typed
-    def get_commissioning_distro_series(cls) -> str:
+    async def get_commissioning_distro_series(cls) -> str:
         """Default Ubuntu release used for commissioning."""
-        return cls.get_config("commissioning_distro_series")
+        return await cls.get_config("commissioning_distro_series")
 
     @typed
-    def set_commissioning_distro_series(cls, series: str):
+    async def set_commissioning_distro_series(cls, series: str):
         """See `get_commissioning_distro_series`."""
-        cls.set_config("commissioning_distro_series", series)
+        await cls.set_config("commissioning_distro_series", series)
 
     @typed
-    def get_http_proxy(cls) -> Optional[str]:
+    async def get_http_proxy(cls) -> Optional[str]:
         """Proxy for APT and HTTP/HTTPS.
 
         This will be passed onto provisioned nodes to use as a proxy for APT
@@ -124,40 +124,40 @@ class MAASType(ObjectType):
         return None if data is None or data == "" else data
 
     @typed
-    def set_http_proxy(cls, url: Optional[str]):
+    async def set_http_proxy(cls, url: Optional[str]):
         """See `get_http_proxy`."""
-        cls.set_config("http_proxy", "" if url is None else url)
+        await cls.set_config("http_proxy", "" if url is None else url)
 
     @typed
-    def get_enable_http_proxy(cls) -> bool:
+    async def get_enable_http_proxy(cls) -> bool:
         """Enable the use of an APT and HTTP/HTTPS proxy.
 
         Provision nodes to use the built-in HTTP proxy (or user specified
         proxy) for APT. MAAS also uses the proxy for downloading boot images.
         """
-        return cls.get_config("enable_http_proxy")
+        return await cls.get_config("enable_http_proxy")
 
     @typed
-    def set_enable_http_proxy(cls, enabled: bool):
+    async def set_enable_http_proxy(cls, enabled: bool):
         """See `get_enable_http_proxy`."""
-        cls.set_config("enable_http_proxy", "1" if enabled else "0")
+        await cls.set_config("enable_http_proxy", "1" if enabled else "0")
 
     @typed
-    def get_curtin_verbose(cls) -> bool:
+    async def get_curtin_verbose(cls) -> bool:
         """Should `curtin` log with high verbosity?
 
         Run the fast-path installer with higher verbosity. This provides more
         detail in the installation logs.
         """
-        return cls.get_config("curtin_verbose")
+        return await cls.get_config("curtin_verbose")
 
     @typed
-    def set_curtin_verbose(cls, verbose: bool):
+    async def set_curtin_verbose(cls, verbose: bool):
         """See `get_curtin_verbose`."""
-        cls.set_config("curtin_verbose", "1" if verbose else "0")
+        await cls.set_config("curtin_verbose", "1" if verbose else "0")
 
     @typed
-    def get_kernel_options(cls) -> Optional[str]:
+    async def get_kernel_options(cls) -> Optional[str]:
         """Kernel options.
 
         Boot parameters to pass to the kernel by default.
@@ -166,12 +166,12 @@ class MAASType(ObjectType):
         return None if data is None or data == "" else data
 
     @typed
-    def set_kernel_options(cls, options: Optional[str]):
+    async def set_kernel_options(cls, options: Optional[str]):
         """See `get_kernel_options`."""
-        cls.set_config("kernel_opts", "" if options is None else options)
+        await cls.set_config("kernel_opts", "" if options is None else options)
 
     @typed
-    def get_upstream_dns(cls) -> list:
+    async def get_upstream_dns(cls) -> list:
         """Upstream DNS server addresses.
 
         Upstream DNS servers used to resolve domains not managed by this MAAS
@@ -183,9 +183,9 @@ class MAASType(ObjectType):
         return [] if data is None else re.split("[,\s]+", data)
 
     @typed
-    def set_upstream_dns(cls, addresses: Optional[Sequence[str]]):
+    async def set_upstream_dns(cls, addresses: Optional[Sequence[str]]):
         """See `get_upstream_dns`."""
-        cls.set_config("upstream_dns", (
+        await cls.set_config("upstream_dns", (
             "" if addresses is None else",".join(addresses)))
 
     class DNSSEC(DescriptiveEnum):
@@ -199,7 +199,7 @@ class MAASType(ObjectType):
         NO = "no", "No (disable DNSSEC)"
 
     @typed
-    def get_dnssec_validation(cls) -> DNSSEC:
+    async def get_dnssec_validation(cls) -> DNSSEC:
         """Enable DNSSEC validation of upstream zones.
 
         Only used when MAAS is running its own DNS server. This value is used
@@ -209,12 +209,12 @@ class MAASType(ObjectType):
         return cls.DNSSEC.lookup(data)
 
     @typed
-    def set_dnssec_validation(cls, validation: DNSSEC):
+    async def set_dnssec_validation(cls, validation: DNSSEC):
         """See `get_dnssec_validation`."""
-        cls.set_config("dnssec_validation", validation.parameter)
+        await cls.set_config("dnssec_validation", validation.parameter)
 
     @typed
-    def get_default_dns_ttl(cls) -> int:
+    async def get_default_dns_ttl(cls) -> int:
         """Default Time-To-Live for DNS records.
 
         If no TTL value is specified at a more specific point this is how long
@@ -223,22 +223,23 @@ class MAASType(ObjectType):
         return int(cls.get_config("default_dns_ttl"))
 
     @typed
-    def set_default_dns_ttl(cls, ttl: int):
+    async def set_default_dns_ttl(cls, ttl: int):
         """See `get_default_dns_ttl`."""
-        cls.set_config("default_dns_ttl", str(ttl))
+        await cls.set_config("default_dns_ttl", str(ttl))
 
     @typed
-    def get_enable_disk_erasing_on_release(cls) -> bool:
+    async def get_enable_disk_erasing_on_release(cls) -> bool:
         """Should nodes' disks be erased prior to releasing."""
-        return cls.get_config("enable_disk_erasing_on_release")
+        return await cls.get_config("enable_disk_erasing_on_release")
 
     @typed
-    def set_enable_disk_erasing_on_release(cls, erase: bool):
+    async def set_enable_disk_erasing_on_release(cls, erase: bool):
         """Should nodes' disks be erased prior to releasing."""
-        cls.set_config("enable_disk_erasing_on_release", "1" if erase else "0")
+        await cls.set_config(
+            "enable_disk_erasing_on_release", "1" if erase else "0")
 
     @typed
-    def get_windows_kms_host(cls) -> Optional[str]:
+    async def get_windows_kms_host(cls) -> Optional[str]:
         """Windows KMS activation host.
 
         FQDN or IP address of the host that provides the KMS Windows
@@ -249,33 +250,33 @@ class MAASType(ObjectType):
         return None if data is None or data == "" else data
 
     @typed
-    def set_windows_kms_host(cls, host: Optional[str]):
+    async def set_windows_kms_host(cls, host: Optional[str]):
         """See `get_windows_kms_host`."""
-        cls.set_config("windows_kms_host", "" if host is None else host)
+        await cls.set_config("windows_kms_host", "" if host is None else host)
 
     @typed
-    def get_boot_images_auto_import(cls) -> bool:
+    async def get_boot_images_auto_import(cls) -> bool:
         """Automatically import/refresh the boot images every 60 minutes."""
-        return cls.get_config("boot_images_auto_import")
+        return await cls.get_config("boot_images_auto_import")
 
     @typed
-    def set_boot_images_auto_import(cls, auto: bool):
+    async def set_boot_images_auto_import(cls, auto: bool):
         """See `get_boot_images_auto_import`."""
-        cls.set_config("boot_images_auto_import", "1" if auto else "0")
+        await cls.set_config("boot_images_auto_import", "1" if auto else "0")
 
     @typed
-    def get_ntp_server(cls) -> str:
+    async def get_ntp_server(cls) -> str:
         """Address of NTP server.
 
         NTP server address passed to nodes via a DHCP response. e.g.
         ntp.ubuntu.com.
         """
-        return cls.get_config("ntp_server")
+        return await cls.get_config("ntp_server")
 
     @typed
-    def set_ntp_server(cls, server: str):
+    async def set_ntp_server(cls, server: str):
         """See `get_ntp_server`."""
-        cls.set_config("ntp_server", server)
+        await cls.set_config("ntp_server", server)
 
     class StorageLayout(DescriptiveEnum):
 
@@ -284,7 +285,7 @@ class MAASType(ObjectType):
         BCACHE = "bcache", "Bcache layout"
 
     @typed
-    def get_default_storage_layout(cls) -> StorageLayout:
+    async def get_default_storage_layout(cls) -> StorageLayout:
         """Default storage layout.
 
         Storage layout that is applied to a node when it is deployed.
@@ -293,12 +294,12 @@ class MAASType(ObjectType):
         return cls.StorageLayout.lookup(data)
 
     @typed
-    def set_default_storage_layout(cls, series: StorageLayout):
+    async def set_default_storage_layout(cls, series: StorageLayout):
         """See `get_default_storage_layout`."""
-        cls.set_config("default_storage_layout", series.parameter)
+        await cls.set_config("default_storage_layout", series.parameter)
 
     @typed
-    def get_default_min_hwe_kernel(cls) -> Optional[str]:
+    async def get_default_min_hwe_kernel(cls) -> Optional[str]:
         """Default minimum kernel version.
 
         The minimum kernel version used on new and commissioned nodes.
@@ -307,38 +308,39 @@ class MAASType(ObjectType):
         return None if data is None or data == "" else data
 
     @typed
-    def set_default_min_hwe_kernel(cls, version: Optional[str]):
+    async def set_default_min_hwe_kernel(cls, version: Optional[str]):
         """See `get_default_min_hwe_kernel`."""
-        cls.set_config(
+        await cls.set_config(
             "default_min_hwe_kernel", "" if version is None else version)
 
     @typed
-    def get_enable_third_party_drivers(cls) -> bool:
+    async def get_enable_third_party_drivers(cls) -> bool:
         """Enable the installation of proprietary drivers, e.g. HPVSA."""
-        return cls.get_config("enable_third_party_drivers")
+        return await cls.get_config("enable_third_party_drivers")
 
     @typed
-    def set_enable_third_party_drivers(cls, enabled: bool):
+    async def set_enable_third_party_drivers(cls, enabled: bool):
         """See `get_enable_third_party_drivers`."""
-        cls.set_config("enable_third_party_drivers", "1" if enabled else "0")
+        await cls.set_config(
+            "enable_third_party_drivers", "1" if enabled else "0")
 
-    def get_config(cls, name: str):
+    async def get_config(cls, name: str):
         """Get a configuration value from MAAS.
 
         Consult your MAAS server for recognised settings. Alternatively, use
         the pre-canned functions also defined on this object.
         """
-        return cls._handler.get_config(name=[name])
+        return await cls._handler.get_config(name=[name])
 
-    def set_config(cls, name: str, value):
+    async def set_config(cls, name: str, value):
         """Set a configuration value in MAAS.
 
         Consult your MAAS server for recognised settings. Alternatively, use
         the pre-canned functions also defined on this object.
         """
-        return cls._handler.set_config(name=[name], value=[value])
+        return await cls._handler.set_config(name=[name], value=[value])
 
-    def _roundtrip(cls):
+    async def _roundtrip(cls):
         """Testing helper: gets each value and sets it again."""
         getters = {
             name[4:]: getattr(cls, name) for name in dir(cls)
@@ -351,12 +353,12 @@ class MAASType(ObjectType):
 
         for name, getter in getters.items():
             print(">>>", name)
-            value = getter()
+            value = await getter()
             print(" ->", repr(value))
             print("   ", type(value))
             setter = setters[name]
             try:
-                setter(value)
+                await setter(value)
             except CallError as error:
                 print(error)
                 print(error.content.decode("utf-8", "replace"))

--- a/maas/client/viscera/tags.py
+++ b/maas/client/viscera/tags.py
@@ -18,17 +18,15 @@ from . import (
 class TagsType(ObjectType):
     """Metaclass for `Tags`."""
 
-    def __iter__(cls):
-        return map(cls._object, cls._handler.read())
-
-    def create(cls, name, *, comment="", definition="", kernel_opts=""):
-        data = cls._handler.new(
+    async def create(cls, name, *, comment="", definition="", kernel_opts=""):
+        data = await cls._handler.new(
             name=name, comment=comment, definition=definition,
             kernel_opts=kernel_opts)
         return cls._object(data)
 
-    def read(cls):
-        return cls(cls)
+    async def read(cls):
+        data = await cls._handler.read()
+        return cls(map(cls._object, data))
 
 
 class Tags(ObjectSet, metaclass=TagsType):

--- a/maas/client/viscera/tests/test_boot_resources.py
+++ b/maas/client/viscera/tests/test_boot_resources.py
@@ -3,28 +3,32 @@
 __all__ = []
 
 import hashlib
-import httplib2
+from http import HTTPStatus
 import io
 import random
-
-from testtools.matchers import (
-    Equals,
-    MatchesDict,
-    MatchesStructure,
-)
 from unittest.mock import (
     call,
     MagicMock,
     sentinel,
 )
 
+import aiohttp
+from testtools.matchers import (
+    Equals,
+    MatchesDict,
+    MatchesStructure,
+)
+
 from .. import boot_resources
-from ..testing import bind
 from ...testing import (
-    make_string,
     make_name_without_spaces,
+    make_string,
     pick_bool,
     TestCase,
+)
+from ..testing import (
+    AsyncMock,
+    bind,
 )
 
 
@@ -360,11 +364,11 @@ class TestBootResources(TestCase):
         # Mock signing. Test checks that its actually called.
         mock_sign = self.patch(boot_resources.utils, "sign")
 
-        # Mock the httplib as the create performs PUT directly to the API.
-        http = MagicMock()
-        http.return_value.request.return_value = (
-            httplib2.Response({"status": 200}), b"")
-        self.patch(boot_resources.httplib2, "Http", http)
+        # Mock ClientSession.put as the create does PUT directly to the API.
+        put = AsyncMock()
+        response = put.return_value = AsyncMock(spec=aiohttp.ClientResponse)
+        response.status = HTTPStatus.OK.value
+        self.patch(boot_resources.aiohttp.ClientSession, "put", put)
 
         # Progress handler called on each chunk.
         progress_handler = MagicMock()
@@ -381,7 +385,7 @@ class TestBootResources(TestCase):
             name=name, architecture=architecture))
         self.assertTrue(resource.sets["20161026"].complete)
 
-        # Check that sign was called.
+        # Check that the request was signed.
         self.assertTrue(mock_sign.called)
 
         # Check that the PUT was called for each chunk.
@@ -389,14 +393,13 @@ class TestBootResources(TestCase):
             call(
                 "http://localhost:5240/MAAS/api/2.0/"
                 "boot-resources/%d/upload/1" % resource_id,
-                "PUT", body=data[0 + i:chunk_size + i],
-                headers={
+                data=data[0 + i:chunk_size + i], headers={
                     'Content-Type': 'application/octet-stream',
                     'Content-Length': str(len(data[0 + i:chunk_size + i])),
                 })
             for i in range(0, len(data), chunk_size)
         ]
-        self.assertEquals(calls, http.return_value.request.call_args_list)
+        self.assertEquals(calls, put.call_args_list)
 
         # Check that progress handler was called on each chunk.
         calls = [
@@ -433,7 +436,6 @@ class TestBootResources(TestCase):
         # upload is complete to get the updated object.
         origin = make_origin()
         BootResources = origin.BootResources
-        BootResource = origin.BootResource
         BootResources._handler.uri = (
             "http://localhost:5240/MAAS/api/2.0/boot-resources/")
         BootResources._handler.path = "/MAAS/api/2.0/boot-resources/"
@@ -465,13 +467,17 @@ class TestBootResources(TestCase):
         # Mock signing. Test checks that its actually called.
         mock_sign = self.patch(boot_resources.utils, "sign")
 
-        # Mock the httplib as the create performs PUT directly to the API.
-        http = MagicMock()
-        http.return_value.request.return_value = (
-            httplib2.Response({"status": 500}), b"Error")
-        self.patch(boot_resources.httplib2, "Http", http)
+        # Mock ClientSession.put as the create does PUT directly to the API.
+        put = AsyncMock()
+        response = put.return_value = AsyncMock(spec=aiohttp.ClientResponse)
+        response.status = HTTPStatus.INTERNAL_SERVER_ERROR.value
+        response.read.return_value = b"Error"
+        self.patch(boot_resources.aiohttp.ClientSession, "put", put)
 
         self.assertRaises(
             boot_resources.CallError, BootResources.create,
             name, architecture, buf,
             title=title, filetype=filetype, chunk_size=chunk_size)
+
+        # Check that the request was signed.
+        self.assertTrue(mock_sign.called)

--- a/maas/client/viscera/tests/test_boot_resources.py
+++ b/maas/client/viscera/tests/test_boot_resources.py
@@ -90,7 +90,7 @@ class TestBootResource(TestCase):
         BootResource = make_origin().BootResource
         BootResource._handler.read.return_value = {
             "id": resource_id, "type": rtype, "name": name,
-            "architecture": architecture, "subarches":subarches,
+            "architecture": architecture, "subarches": subarches,
             "sets": sets}
 
         resource = BootResource.read(resource_id)

--- a/maas/client/viscera/tests/test_boot_source_selections.py
+++ b/maas/client/viscera/tests/test_boot_source_selections.py
@@ -9,14 +9,15 @@ from testtools.matchers import (
     MatchesStructure,
 )
 
-from .. import boot_sources
-from .. import boot_source_selections
-from ..testing import bind
+from .. import (
+    boot_source_selections,
+    boot_sources,
+)
 from ...testing import (
     make_name_without_spaces,
-    pick_bool,
     TestCase,
 )
+from ..testing import bind
 
 
 def make_origin():

--- a/maas/client/viscera/tests/test_boot_sources.py
+++ b/maas/client/viscera/tests/test_boot_sources.py
@@ -10,12 +10,11 @@ from testtools.matchers import (
 )
 
 from .. import boot_sources
-from ..testing import bind
 from ...testing import (
     make_name_without_spaces,
-    pick_bool,
     TestCase,
 )
+from ..testing import bind
 
 
 def make_origin():

--- a/maas/client/viscera/tests/test_events.py
+++ b/maas/client/viscera/tests/test_events.py
@@ -8,10 +8,7 @@ from itertools import (
     count,
 )
 import random
-from unittest.mock import (
-    MagicMock,
-    Mock,
-)
+from unittest.mock import sentinel
 
 from testtools.matchers import (
     Equals,
@@ -19,13 +16,13 @@ from testtools.matchers import (
 )
 
 from .. import events
-from ..testing import bind
 from ...testing import (
     make_mac_address,
     make_name_without_spaces,
     randrange,
     TestCase,
 )
+from ..testing import bind
 
 
 event_ids = count(1)
@@ -46,7 +43,19 @@ def make_Event_dict():
 def make_origin():
     # Create a new origin with Events and Event. The former refers to the
     # latter via the origin, hence why it must be bound.
-    return bind(events.Events, events.Event)
+    origin = bind(events.Events, events.Event)
+    # Prepare a sensible default response from Events.query.
+    events_query = origin.session.handlers[events.Events.__name__].query
+    events_query.return_value = make_queried_events()
+    return origin
+
+
+def make_queried_events():
+    """Mimic the object returned from a query."""
+    return {
+        "events": [], "prev_uri": sentinel.prev_uri,
+        "next_uri": sentinel.next_uri,
+    }
 
 
 class TestEventsQuery(TestCase):

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -2,17 +2,14 @@
 
 __all__ = []
 
-import base64
-
 from testtools.matchers import Equals
 
 from .. import machines
-from ..testing import bind
 from ...testing import (
     make_name_without_spaces,
-    make_string,
     TestCase,
 )
+from ..testing import bind
 
 
 def make_origin():

--- a/maas/client/viscera/tests/test_users.py
+++ b/maas/client/viscera/tests/test_users.py
@@ -8,12 +8,12 @@ from testtools.matchers import (
 )
 
 from .. import users
-from ..testing import bind
 from ...testing import (
     make_name_without_spaces,
     pick_bool,
     TestCase,
 )
+from ..testing import bind
 
 
 def make_origin():
@@ -68,7 +68,7 @@ class TestUsers(TestCase):
         Users._handler.create.return_value = {
             "username": username, "email": email, "is_superuser": is_admin}
 
-        user = Users.create(username, password, is_admin=is_admin)
+        Users.create(username, password, is_admin=is_admin)
         Users._handler.create.assert_called_once_with(
             username=username, password=password, email=email,
             is_superuser='1' if is_admin else '0')
@@ -84,7 +84,7 @@ class TestUsers(TestCase):
         Users._handler.create.return_value = {
             "username": username, "email": email, "is_superuser": is_admin}
 
-        user = Users.create(username, password, email=email, is_admin=is_admin)
+        Users.create(username, password, email=email, is_admin=is_admin)
         Users._handler.create.assert_called_once_with(
             username=username, password=password, email=email,
             is_superuser='1' if is_admin else '0')

--- a/maas/client/viscera/users.py
+++ b/maas/client/viscera/users.py
@@ -17,28 +17,26 @@ from . import (
 class UsersType(ObjectType):
     """Metaclass for `Users`."""
 
-    def __iter__(cls):
-        return map(cls._object, cls._handler.read())
-
-    def whoami(cls):
+    async def whoami(cls):
         """Get the logged-in user."""
-        data = cls._handler.whoami()
+        data = await cls._handler.whoami()
         return cls._object(data)
 
-    def create(cls, username, password, *, email=None, is_admin=False):
+    async def create(cls, username, password, *, email=None, is_admin=False):
         if email is None:
             email = "%s@null.maas.io" % username
-        data = cls._handler.create(
+        data = await cls._handler.create(
             username=username, email=email, password=password,
             is_superuser='1' if is_admin else '0')
+        return cls._object(data)
+
+    async def read(cls):
+        data = await cls._handler.read()
+        return cls(map(cls._object, data))
 
 
 class Users(ObjectSet, metaclass=UsersType):
     """The set of users."""
-
-    @classmethod
-    def read(cls):
-        return cls(cls)
 
 
 class User(Object):

--- a/maas/client/viscera/version.py
+++ b/maas/client/viscera/version.py
@@ -20,8 +20,8 @@ def parse_version(version):
 class VersionType(ObjectType):
     """Metaclass for `Version`."""
 
-    def read(cls):
-        data = cls._handler.read()
+    async def read(cls):
+        data = await cls._handler.read()
         return cls(data)
 
 

--- a/maas/client/viscera/zones.py
+++ b/maas/client/viscera/zones.py
@@ -18,11 +18,9 @@ from . import (
 class ZonesType(ObjectType):
     """Metaclass for `Zones`."""
 
-    def __iter__(cls):
-        return map(cls._object, cls._handler.read())
-
-    def read(cls):
-        return cls(cls)
+    async def read(cls):
+        data = await cls._handler.read()
+        return cls(map(cls._object, data))
 
 
 class ZoneNotFound(Exception):
@@ -35,8 +33,8 @@ class Zones(ObjectSet, metaclass=ZonesType):
 
 class ZoneType(ObjectType):
 
-    def read(cls, name):
-        data = cls._handler.read(name=name)
+    async def read(cls, name):
+        data = await cls._handler.read(name=name)
         return cls(data)
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,13 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries',
     ],
-    namespace_packages = ['maas'],
+    namespace_packages=['maas'],
     packages=find_packages(),
     package_data={
         'maas.client.bones.tests': ['*.json'],
     },
     install_requires={
+        "aiohttp >= 1.1.4",
         "argcomplete >= 1.0",
         "beautifulsoup4 >= 4.4.1",
         "colorclass >= 1.2.0",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "argcomplete >= 1.0",
         "beautifulsoup4 >= 4.4.1",
         "colorclass >= 1.2.0",
-        "httplib2 >= 0.8",
         "oauthlib >= 1.0.3",
         "pytz >= 2014.10",
         "PyYAML >= 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py35
+envlist = py35, lint
 
 [testenv:py35]
 commands = coverage run setup.py test {posargs}
 sitepackages = False
-usedevelop = True
 deps = coverage
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ sitepackages = False
 deps = coverage
 
 [testenv:lint]
-commands = flake8 maas
+commands = flake8 maas --isolated --ignore=E402,E123,E731
 sitepackages = False
 skip_install = True
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,14 @@
 [tox]
 envlist = py35
 
-[testenv]
+[testenv:py35]
 commands = coverage run setup.py test {posargs}
 sitepackages = False
+usedevelop = True
 deps = coverage
+
+[testenv:lint]
+commands = flake8 maas
+sitepackages = False
+skip_install = True
+deps = flake8


### PR DESCRIPTION
Switch to asyncio and aiohttp (with one small exception which can be done later).

This was fairly straightforward, except that asyncio has at least [one quirk](https://bugs.python.org/issue28725) which I consider a bug but which upstream consider to be part of the design. I'm new to this so I'm going to wait and see.

The one special thing that this branch does is add the `Asynchronous` metaclass. This ensures that all co-routine methods (which means methods defined with `async def`) in a class are wrapped such that they'll work as normal within the event-loop but block when called from outside. This means that the interactive experience of using the higher-level "origin" (aka "viscera") API remains the same.