### PR TITLE
Client connect and login.

### DIFF
--- a/maas/client/__init__.py
+++ b/maas/client/__init__.py
@@ -1,0 +1,46 @@
+"""Basic entry points."""
+
+import threading as _threading
+
+
+def _connect(url, *, apikey=None, insecure=False):
+    """Make an `Origin` by connecting with an apikey.
+
+    :return: A tuple of ``profile`` and ``origin``, where the former is an
+        unsaved `Profile` instance, and the latter is an `Origin` instance
+        made using the profile.
+    """
+    _load()
+    return connect(url, apikey=apikey, insecure=insecure)
+
+
+def _login(url, *, username=None, password=None, insecure=False):
+    """Make an `Origin` by logging-in with a username and password.
+
+    :return: A tuple of ``profile`` and ``origin``, where the former is an
+        unsaved `Profile` instance, and the latter is an `Origin` instance
+        made using the profile.
+    """
+    _load()
+    return login(url, username=username, password=password, insecure=insecure)
+
+
+# Begin with stubs. We keep the stubs in _connect and _login for run-time
+# reference, for the curious, but also for testing, where we verify that the
+# stubs' signatures perfectly match those of the concrete implementation.
+connect = _connect
+login = _login
+
+
+# Paranoia, belt-n-braces, call it what you will: replace the stubs only when
+# holding this lock, just in case.
+_load_lock = _threading.RLock()
+
+
+def _load():
+    """Replace stubs with concrete implementations."""
+    global connect, login
+    with _load_lock:
+        from .viscera import Origin
+        connect = Origin.connect
+        login = Origin.login

--- a/maas/client/__init__.py
+++ b/maas/client/__init__.py
@@ -1,46 +1,35 @@
 """Basic entry points."""
 
-import threading as _threading
+from . import _client
 
 
-def _connect(url, *, apikey=None, insecure=False):
-    """Make an `Origin` by connecting with an apikey.
+def connect(url, *, apikey=None, insecure=False):
+    """Connect to MAAS at `url` using a previously obtained API key.
 
-    :return: A tuple of ``profile`` and ``origin``, where the former is an
-        unsaved `Profile` instance, and the latter is an `Origin` instance
-        made using the profile.
+    :param url: The URL of MAAS, e.g. http://maas.example.com:5240/MAAS/
+    :param apikey: The API key to use, e.g.
+        SkTvsyHhzkREvvdtNk:Ywn5FvXVupVPvNUhrN:cm3Q2f5naXYPYsrPDPfQy9Q9cUFaEgbM
+    :param insecure: Whether to check TLS certificates when using HTTPS.
+
+    :return: A client object.
     """
-    _load()
-    return connect(url, apikey=apikey, insecure=insecure)
+    from .viscera import Origin  # Lazy.
+    profile, origin = Origin.connect(
+        url, apikey=apikey, insecure=insecure)
+    return _client.Client(origin)
 
 
-def _login(url, *, username=None, password=None, insecure=False):
-    """Make an `Origin` by logging-in with a username and password.
+def login(url, *, username=None, password=None, insecure=False):
+    """Connect to MAAS at `url` with a user name and password.
 
-    :return: A tuple of ``profile`` and ``origin``, where the former is an
-        unsaved `Profile` instance, and the latter is an `Origin` instance
-        made using the profile.
+    :param url: The URL of MAAS, e.g. http://maas.example.com:5240/MAAS/
+    :param username: The user name to use, e.g. fred.
+    :param password: The user's password.
+    :param insecure: Whether to check TLS certificates when using HTTPS.
+
+    :return: A client object.
     """
-    _load()
-    return login(url, username=username, password=password, insecure=insecure)
-
-
-# Begin with stubs. We keep the stubs in _connect and _login for run-time
-# reference, for the curious, but also for testing, where we verify that the
-# stubs' signatures perfectly match those of the concrete implementation.
-connect = _connect
-login = _login
-
-
-# Paranoia, belt-n-braces, call it what you will: replace the stubs only when
-# holding this lock, just in case.
-_load_lock = _threading.RLock()
-
-
-def _load():
-    """Replace stubs with concrete implementations."""
-    global connect, login
-    with _load_lock:
-        from .viscera import Origin
-        connect = Origin.connect
-        login = Origin.login
+    from .viscera import Origin  # Lazy.
+    profile, origin = Origin.login(
+        url, username=username, password=password, insecure=insecure)
+    return _client.Client(origin)

--- a/maas/client/_client.py
+++ b/maas/client/_client.py
@@ -1,9 +1,9 @@
-"""Client façade."""
+"""Client facade."""
 
 from functools import update_wrapper
 
 
-class Façade:
+class Facade:
     """Present a simplified API for interacting with MAAS.
 
     The viscera API separates set-based interactions from those on individual
@@ -13,12 +13,12 @@ class Façade:
 
     However, we want to present a simplified commingled namespace to users of
     MAAS's *client* API. For example, all entry points related to machines
-    should be available as ``client.machines``. This façade class allows us to
+    should be available as ``client.machines``. This facade class allows us to
     present that commingled namespace without coding it as such.
     """
 
     def __init__(self, client, name, methods):
-        super(Façade, self).__init__()
+        super(Facade, self).__init__()
         self._client = client
         self._name = name
         self._populate(methods)
@@ -31,8 +31,8 @@ class Façade:
         return "<%s>" % self._name
 
 
-class FaçadeDescriptor:
-    """Lazily create a façade on first use.
+class FacadeDescriptor:
+    """Lazily create a facade on first use.
 
     It will be stored in the instance dictionary using the given name. This
     should match the name by which the descriptor is bound into the instance
@@ -47,19 +47,19 @@ class FaçadeDescriptor:
     """
 
     def __init__(self, name, factory):
-        super(FaçadeDescriptor, self).__init__()
+        super(FacadeDescriptor, self).__init__()
         self.name, self.factory = name, factory
 
     def __get__(self, obj, typ=None):
         methods = self.factory(obj._origin)
-        façade = Façade(obj, self.name, methods)
-        obj.__dict__[self.name] = façade
-        return façade
+        facade = Facade(obj, self.name, methods)
+        obj.__dict__[self.name] = facade
+        return facade
 
 
-def façade(factory):
-    """Declare a method as a façade factory."""
-    wrapper = FaçadeDescriptor(factory.__name__, factory)
+def facade(factory):
+    """Declare a method as a facade factory."""
+    wrapper = FacadeDescriptor(factory.__name__, factory)
     return update_wrapper(wrapper, factory)
 
 
@@ -70,7 +70,7 @@ class Client:
         super(Client, self).__init__()
         self._origin = origin
 
-    @façade
+    @facade
     def machines(origin):
         return {
             "allocate": origin.Machines.allocate,
@@ -78,7 +78,7 @@ class Client:
             "list": origin.Machines.read,
         }
 
-    @façade
+    @facade
     def devices(origin):
         return {
             "get": origin.Device.read,

--- a/maas/client/_client.py
+++ b/maas/client/_client.py
@@ -1,0 +1,86 @@
+"""Client façade."""
+
+from functools import update_wrapper
+
+
+class Façade:
+    """Present a simplified API for interacting with MAAS.
+
+    The viscera API separates set-based interactions from those on individual
+    objects — e.g. Machines and Machine — which mirrors the way MAAS's API is
+    actually constructed, helps to avoid namespace clashes, and makes testing
+    cleaner.
+
+    However, we want to present a simplified commingled namespace to users of
+    MAAS's *client* API. For example, all entry points related to machines
+    should be available as ``client.machines``. This façade class allows us to
+    present that commingled namespace without coding it as such.
+    """
+
+    def __init__(self, client, name, methods):
+        super(Façade, self).__init__()
+        self._client = client
+        self._name = name
+        self._populate(methods)
+
+    def _populate(self, methods):
+        for name, func in methods.items():
+            setattr(self, name, func)
+
+    def __repr__(self):
+        return "<%s>" % self._name
+
+
+class FaçadeDescriptor:
+    """Lazily create a façade on first use.
+
+    It will be stored in the instance dictionary using the given name. This
+    should match the name by which the descriptor is bound into the instance
+    class's namespace: as this is a non-data descriptor [1] this will yield
+    create-on-first-use behaviour.
+
+    The factory function should accept a single argument, an `Origin`, and
+    return a dict mapping method names to methods of objects obtained from the
+    origin.
+
+    [1] https://docs.python.org/3.5/howto/descriptor.html#descriptor-protocol
+    """
+
+    def __init__(self, name, factory):
+        super(FaçadeDescriptor, self).__init__()
+        self.name, self.factory = name, factory
+
+    def __get__(self, obj, typ=None):
+        methods = self.factory(obj._origin)
+        façade = Façade(obj, self.name, methods)
+        obj.__dict__[self.name] = façade
+        return façade
+
+
+def façade(factory):
+    """Declare a method as a façade factory."""
+    wrapper = FaçadeDescriptor(factory.__name__, factory)
+    return update_wrapper(wrapper, factory)
+
+
+class Client:
+    """A simplified API for interacting with MAAS."""
+
+    def __init__(self, origin):
+        super(Client, self).__init__()
+        self._origin = origin
+
+    @façade
+    def machines(origin):
+        return {
+            "allocate": origin.Machines.allocate,
+            "get": origin.Machine.read,
+            "list": origin.Machines.read,
+        }
+
+    @façade
+    def devices(origin):
+        return {
+            "get": origin.Device.read,
+            "list": origin.Devices.read,
+        }

--- a/maas/client/tests/test__client.py
+++ b/maas/client/tests/test__client.py
@@ -28,7 +28,7 @@ class TestClient(TestCase):
 
     def test__client_maps_devices(self):
         self.assertThat(self.client, MatchesClient(
-            devices=MatchesFaçade(
+            devices=MatchesFacade(
                 get=self.origin.Device.read,
                 list=self.origin.Devices.read,
             ),
@@ -36,7 +36,7 @@ class TestClient(TestCase):
 
     def test__client_maps_machines(self):
         self.assertThat(self.client, MatchesClient(
-            machines=MatchesFaçade(
+            machines=MatchesFacade(
                 allocate=self.origin.Machines.allocate,
                 get=self.origin.Machine.read,
                 list=self.origin.Machines.read,
@@ -44,19 +44,19 @@ class TestClient(TestCase):
         ))
 
 
-def MatchesClient(**façades):
-    """Matches a `_client.Client` with the given façades."""
+def MatchesClient(**facades):
+    """Matches a `_client.Client` with the given facades."""
     return MatchesAll(
         IsInstance(_client.Client),
-        MatchesStructure(**façades),
+        MatchesStructure(**facades),
         first_only=True,
     )
 
 
-def MatchesFaçade(**methods):
-    """Matches a `_client.Façade` with the given methods."""
+def MatchesFacade(**methods):
+    """Matches a `_client.Facade` with the given methods."""
     return MatchesAll(
-        IsInstance(_client.Façade),
+        IsInstance(_client.Facade),
         MatchesStructure.byEquality(**methods),
         first_only=True,
     )

--- a/maas/client/tests/test__client.py
+++ b/maas/client/tests/test__client.py
@@ -1,0 +1,62 @@
+"""Tests for `maas.client._client`."""
+
+__all__ = []
+
+from unittest.mock import Mock
+
+from testtools.matchers import (
+    IsInstance,
+    MatchesAll,
+    MatchesStructure,
+)
+
+from .. import (
+    _client,
+    viscera,
+)
+from ..testing import TestCase
+
+
+class TestClient(TestCase):
+    """Tests for the simplified client."""
+
+    def setUp(self):
+        super(TestClient, self).setUp()
+        self.session = Mock(name="session", handlers={})
+        self.origin = viscera.Origin(self.session)
+        self.client = _client.Client(self.origin)
+
+    def test__client_maps_devices(self):
+        self.assertThat(self.client, MatchesClient(
+            devices=MatchesFaçade(
+                get=self.origin.Device.read,
+                list=self.origin.Devices.read,
+            ),
+        ))
+
+    def test__client_maps_machines(self):
+        self.assertThat(self.client, MatchesClient(
+            machines=MatchesFaçade(
+                allocate=self.origin.Machines.allocate,
+                get=self.origin.Machine.read,
+                list=self.origin.Machines.read,
+            ),
+        ))
+
+
+def MatchesClient(**façades):
+    """Matches a `_client.Client` with the given façades."""
+    return MatchesAll(
+        IsInstance(_client.Client),
+        MatchesStructure(**façades),
+        first_only=True,
+    )
+
+
+def MatchesFaçade(**methods):
+    """Matches a `_client.Façade` with the given methods."""
+    return MatchesAll(
+        IsInstance(_client.Façade),
+        MatchesStructure.byEquality(**methods),
+        first_only=True,
+    )

--- a/maas/client/tests/test_client.py
+++ b/maas/client/tests/test_client.py
@@ -1,0 +1,45 @@
+"""Tests for `maas.client`."""
+
+__all__ = []
+
+from inspect import (
+    getdoc,
+    signature,
+)
+
+from testtools.matchers import (
+    Equals,
+    Is,
+    Not,
+)
+
+from ... import client
+from ..testing import TestCase
+from ..viscera import Origin
+
+
+class TestStubs(TestCase):
+    """Tests that stubs match their concrete counterparts."""
+
+    def setUp(self):
+        super(TestStubs, self).setUp()
+        client._load()  # Ensure the stubs have been replaced.
+
+    def test__connect_stub_matches_Origin_connect(self):
+        stub, real = client._connect, client.connect
+        self.assertThat(real, Equals(Origin.connect))
+        self.assertSignaturesAndDocsMatch(stub, real)
+
+    def test__login_stub_matches_Origin_login(self):
+        stub, real = client._login, client.login
+        self.assertThat(real, Equals(Origin.login))
+        self.assertSignaturesAndDocsMatch(stub, real)
+
+    def assertSignaturesAndDocsMatch(self, stub, real):
+        self.assertThat(stub, Not(Is(real)))
+        sig_stub = signature(client._connect)
+        sig_real = signature(client.connect)
+        self.assertThat(sig_stub, Equals(sig_real))
+        doc_real = getdoc(real)
+        doc_stub = getdoc(stub)
+        self.assertThat(doc_stub, Equals(doc_real))

--- a/maas/client/tests/test_client.py
+++ b/maas/client/tests/test_client.py
@@ -2,44 +2,57 @@
 
 __all__ = []
 
-from inspect import (
-    getdoc,
-    signature,
-)
+from inspect import signature
+from unittest.mock import sentinel
 
 from testtools.matchers import (
     Equals,
     Is,
+    IsInstance,
     Not,
 )
 
+from .. import _client
 from ... import client
 from ..testing import TestCase
 from ..viscera import Origin
 
 
-class TestStubs(TestCase):
-    """Tests that stubs match their concrete counterparts."""
+class TestFunctions(TestCase):
+    """Tests for module functions."""
 
-    def setUp(self):
-        super(TestStubs, self).setUp()
-        client._load()  # Ensure the stubs have been replaced.
+    def test__connect_matches_Origin_connect(self):
+        stub, real = client.connect, Origin.connect
+        self.assertSignaturesMatch(stub, real)
 
-    def test__connect_stub_matches_Origin_connect(self):
-        stub, real = client._connect, client.connect
-        self.assertThat(real, Equals(Origin.connect))
-        self.assertSignaturesAndDocsMatch(stub, real)
+    def test__connect_calls_through_to_Origin(self):
+        connect = self.patch(Origin, "connect")
+        connect.return_value = sentinel.profile, sentinel.origin
+        client_object = client.connect(
+            sentinel.url, apikey=sentinel.apikey, insecure=sentinel.insecure)
+        connect.assert_called_once_with(
+            sentinel.url, apikey=sentinel.apikey, insecure=sentinel.insecure)
+        self.assertThat(client_object, IsInstance(_client.Client))
+        self.assertThat(client_object._origin, Is(sentinel.origin))
 
-    def test__login_stub_matches_Origin_login(self):
-        stub, real = client._login, client.login
-        self.assertThat(real, Equals(Origin.login))
-        self.assertSignaturesAndDocsMatch(stub, real)
+    def test__login_matches_Origin_login(self):
+        stub, real = client.login, Origin.login
+        self.assertSignaturesMatch(stub, real)
 
-    def assertSignaturesAndDocsMatch(self, stub, real):
+    def test__login_calls_through_to_Origin(self):
+        login = self.patch(Origin, "login")
+        login.return_value = sentinel.profile, sentinel.origin
+        client_object = client.login(
+            sentinel.url, username=sentinel.username,
+            password=sentinel.password, insecure=sentinel.insecure)
+        login.assert_called_once_with(
+            sentinel.url, username=sentinel.username,
+            password=sentinel.password, insecure=sentinel.insecure)
+        self.assertThat(client_object, IsInstance(_client.Client))
+        self.assertThat(client_object._origin, Is(sentinel.origin))
+
+    def assertSignaturesMatch(self, stub, real):
         self.assertThat(stub, Not(Is(real)))
-        sig_stub = signature(client._connect)
-        sig_real = signature(client.connect)
+        sig_stub = signature(client.connect)
+        sig_real = signature(Origin.connect)
         self.assertThat(sig_stub, Equals(sig_real))
-        doc_real = getdoc(real)
-        doc_stub = getdoc(stub)
-        self.assertThat(doc_stub, Equals(doc_real))

--- a/maas/client/utils/__init__.py
+++ b/maas/client/utils/__init__.py
@@ -38,6 +38,7 @@ from urllib.parse import (
 
 from oauthlib import oauth1
 
+from .async import asynchronous
 from .creds import Credentials
 from .multipart import (
     build_multipart_message,
@@ -336,12 +337,13 @@ class Spinner:
 
 
 @typed
-def fetch_api_description(
+@asynchronous
+async def fetch_api_description(
         url: ParseResult, credentials: Optional[Credentials],
         insecure: bool):
     """Fetch the API description from the remote MAAS instance."""
     # Circular import.
     from .. import bones
-    session = bones.SessionAPI.fromURL(
+    session = await bones.SessionAPI.fromURL(
         url.geturl(), credentials=credentials, insecure=insecure)
     return session.description

--- a/maas/client/utils/tests/test_utils.py
+++ b/maas/client/utils/tests/test_utils.py
@@ -7,21 +7,30 @@ from functools import partial
 from itertools import cycle
 import os
 import os.path
+import random
 from unittest.mock import sentinel
+from urllib.parse import urlparse
 
 from testtools.matchers import (
     AfterPreprocessing,
     Equals,
+    Is,
     MatchesListwise,
 )
 from twisted.internet.task import Clock
 
-from ... import utils
+from ... import (
+    bones,
+    utils,
+)
 from ...testing import (
+    make_name,
     make_name_without_spaces,
     make_string,
     TestCase,
 )
+from ...viscera.testing import AsyncMock
+from ..creds import Credentials
 
 
 class TestMAASOAuth(TestCase):
@@ -430,3 +439,23 @@ class TestRetries(TestCase):
         self.assertRetry(clock, next(gen_retries), 103.5, -98.5, 0.0)
         # All done.
         self.assertRaises(StopIteration, next, gen_retries)
+
+
+class TestFetchAPIDescription(TestCase):
+    """Tests for `fetch_api_description`."""
+
+    def test__calls_through_to_SessionAPI(self):
+        fromURL = self.patch(bones.SessionAPI, "fromURL", AsyncMock())
+        fromURL.return_value.description = sentinel.description
+
+        url = urlparse("http://maas.example.com:5420/MAAS/")
+        credentials = Credentials(
+            make_name('consumer_key'), make_name('token_key'),
+            make_name('secret_key'))
+        insecure = random.choice((True, False))
+
+        self.assertThat(
+            utils.fetch_api_description(url, credentials, insecure),
+            Is(sentinel.description))
+        fromURL.assert_called_once_with(
+            url.geturl(), credentials=credentials, insecure=insecure)


### PR DESCRIPTION
This is the first piece of work towards producing the API as described in the document _17.04 MAAS Roadmap: python-libmaas_ (which isn't public but should be). It adds `maas.client.{connect,login}` functions that each return an object that has (at present) `machines` and `devices` attributes.