### PR TITLE
Fix spurious test failure in test_obtain_credentials_from_stdin

### DIFF
--- a/maas/client/bones/tests/test.py
+++ b/maas/client/bones/tests/test.py
@@ -23,7 +23,7 @@ from testtools.matchers import (
 from .. import testing
 from ... import bones
 from ...testing import TestCase
-from ...utils.tests.test_auth import make_credentials
+from ...utils.tests.test_auth import make_Credentials
 
 
 class TestSessionAPI(TestCase):
@@ -49,7 +49,7 @@ class TestSessionAPI(TestCase):
 
     def test__fromURL_sets_credentials_on_session(self):
         fixture = self.useFixture(testing.DescriptionServer())
-        credentials = make_credentials()
+        credentials = make_Credentials()
         session = self.loop.run_until_complete(
             bones.SessionAPI.fromURL(fixture.url, credentials=credentials))
         self.assertIs(credentials, session.credentials)

--- a/maas/client/bones/tests/test_helpers.py
+++ b/maas/client/bones/tests/test_helpers.py
@@ -23,7 +23,7 @@ from ...utils import (
     api_url,
     profiles,
 )
-from ...utils.testing import make_credentials
+from ...utils.testing import make_Credentials
 
 
 class TestFetchAPIDescription(TestCase):
@@ -87,7 +87,7 @@ class TestConnect(TestCase):
         self.assertThat(profile.credentials, Is(None))
 
     def test__connected_when_apikey_provided(self):
-        credentials = make_credentials()
+        credentials = make_Credentials()
         # Connect with an apikey.
         profile = helpers.connect(
             "http://example.org:5240/MAAS/", apikey=str(credentials))
@@ -155,7 +155,7 @@ class TestLogin(TestCase):
         self.assertThat(profile.credentials, Is(None))
 
     def test__authenticated_when_username_and_password_provided(self):
-        credentials = make_credentials()
+        credentials = make_Credentials()
         helpers.obtain_token.return_value = credentials
         # Log-in with a user-name and a password.
         profile = helpers.login("http://foo:bar@example.org:5240/MAAS/")

--- a/maas/client/bones/tests/test_helpers.py
+++ b/maas/client/bones/tests/test_helpers.py
@@ -23,7 +23,7 @@ from ...utils import (
     api_url,
     profiles,
 )
-from ...utils.tests.test_auth import make_credentials
+from ...utils.testing import make_credentials
 
 
 class TestFetchAPIDescription(TestCase):

--- a/maas/client/utils/testing.py
+++ b/maas/client/utils/testing.py
@@ -1,0 +1,12 @@
+"""Testing helpers for `maas.client.utils`."""
+
+from ..testing import make_name_without_spaces
+from .creds import Credentials
+
+
+def make_credentials():
+    return Credentials(
+        make_name_without_spaces('consumer_key'),
+        make_name_without_spaces('token_key'),
+        make_name_without_spaces('secret_key'),
+    )

--- a/maas/client/utils/testing.py
+++ b/maas/client/utils/testing.py
@@ -4,7 +4,7 @@ from ..testing import make_name_without_spaces
 from .creds import Credentials
 
 
-def make_credentials():
+def make_Credentials():
     return Credentials(
         make_name_without_spaces('consumer_key'),
         make_name_without_spaces('token_key'),

--- a/maas/client/utils/tests/test_auth.py
+++ b/maas/client/utils/tests/test_auth.py
@@ -10,7 +10,7 @@ from unittest.mock import (
 
 from .. import auth
 from ...testing import TestCase
-from ..testing import make_credentials
+from ..testing import make_Credentials
 
 
 class TestAuth(TestCase):
@@ -30,7 +30,7 @@ class TestAuth(TestCase):
     def test_obtain_credentials_from_stdin(self):
         # When "-" is passed to obtain_credentials, it reads credentials from
         # stdin, trims whitespace, and converts it into a 3-tuple of creds.
-        credentials = make_credentials()
+        credentials = make_Credentials()
         stdin = self.patch(sys, "stdin")
         stdin.readline.return_value = str(credentials) + "\n"
         self.assertEqual(credentials, auth.obtain_credentials("-"))
@@ -39,7 +39,7 @@ class TestAuth(TestCase):
     def test_obtain_credentials_via_getpass(self):
         # When None is passed to obtain_credentials, it attempts to obtain
         # credentials via getpass, then converts it into a 3-tuple of creds.
-        credentials = make_credentials()
+        credentials = make_Credentials()
         getpass = self.patch(auth, "getpass")
         getpass.return_value = str(credentials)
         self.assertEqual(credentials, auth.obtain_credentials(None))

--- a/maas/client/utils/tests/test_auth.py
+++ b/maas/client/utils/tests/test_auth.py
@@ -9,19 +9,8 @@ from unittest.mock import (
 )
 
 from .. import auth
-from ...testing import (
-    make_name,
-    TestCase,
-)
-from ..creds import Credentials
-
-
-def make_credentials():
-    return Credentials(
-        make_name('consumer_key'),
-        make_name('token_key'),
-        make_name('secret_key'),
-        )
+from ...testing import TestCase
+from ..testing import make_credentials
 
 
 class TestAuth(TestCase):

--- a/maas/client/utils/tests/test_profiles.py
+++ b/maas/client/utils/tests/test_profiles.py
@@ -24,7 +24,7 @@ from ..profiles import (
     ProfileNotFound,
     ProfileStore,
 )
-from .test_auth import make_credentials
+from ..testing import make_credentials
 
 
 def make_profile():

--- a/maas/client/utils/tests/test_profiles.py
+++ b/maas/client/utils/tests/test_profiles.py
@@ -24,13 +24,13 @@ from ..profiles import (
     ProfileNotFound,
     ProfileStore,
 )
-from ..testing import make_credentials
+from ..testing import make_Credentials
 
 
 def make_profile():
     return Profile(
         name=make_name_without_spaces("name"), url="http://example.com:5240/",
-        credentials=make_credentials(), description={"resources": []},
+        credentials=make_Credentials(), description={"resources": []},
         something=make_name_without_spaces("something"))
 
 


### PR DESCRIPTION
https://travis-ci.org/maas/python-libmaas/builds/205000326 reported:

```
FAIL: test_obtain_credentials_from_stdin (maas.client.utils.tests.test_auth.TestAuth)
maas.client.utils.tests.test_auth.TestAuth.test_obtain_credentials_from_stdin
----------------------------------------------------------------------
testtools.testresult.real._StringException: Traceback (most recent call last):
  File "/home/travis/build/maas/python-libmaas/maas/client/utils/tests/test_auth.py", line 47, in test_obtain_credentials_from_stdin
    self.assertEqual(credentials, auth.obtain_credentials("-"))
  File "/home/travis/build/maas/python-libmaas/.eggs/testtools-2.2.0-py3.5.egg/testtools/testcase.py", line 411, in assertEqual
    self.assertThat(observed, matcher, message)
  File "/home/travis/build/maas/python-libmaas/.eggs/testtools-2.2.0-py3.5.egg/testtools/testcase.py", line 498, in assertThat
    raise mismatch_error
testtools.matchers._impl.MismatchError: !=:
reference = Credentials(consumer_key='consumer_key-v7FKaB', token_key='token_key-xnuMCg', token_secret='secret_key-97WAB ')
actual    = Credentials(consumer_key='consumer_key-v7FKaB', token_key='token_key-xnuMCg', token_secret='secret_key-97WAB')
```

The problem is that `make_name` was being used to create dummy credentials instead of `make_name_without_spaces`. Credentials never contains spaces in MAAS.