### PR TITLE
Refactor AsyncMock and Awaitable into four different mocks.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+branch = True
+source =
+  maas/client
+omit =
+  */testing.py
+  */tests/*.py
+
+[html]
+title =
+  Coverage for python-libmaas

--- a/maas/client/bones/tests/test_helpers.py
+++ b/maas/client/bones/tests/test_helpers.py
@@ -14,7 +14,7 @@ from .. import (
     testing,
 )
 from ...testing import (
-    AsyncMock,
+    AsyncCallableMock,
     make_name,
     make_name_without_spaces,
     TestCase,
@@ -74,7 +74,7 @@ class TestConnect(TestCase):
         super(TestConnect, self).setUp()
         self.patch(
             helpers, "fetch_api_description",
-            AsyncMock(return_value={}))
+            AsyncCallableMock(return_value={}))
 
     def test__anonymous_when_no_apikey_provided(self):
         # Connect without an apikey.
@@ -140,7 +140,7 @@ class TestLogin(TestCase):
         self.patch(helpers, "obtain_token").return_value = None
         self.patch(
             helpers, "fetch_api_description",
-            AsyncMock(return_value={}))
+            AsyncCallableMock(return_value={}))
 
     def test__anonymous_when_neither_username_nor_password_provided(self):
         # Log-in without a user-name or a password.

--- a/maas/client/viscera/boot_resources.py
+++ b/maas/client/viscera/boot_resources.py
@@ -214,17 +214,17 @@ class BootResourcesType(ObjectType):
             utils.sign(upload_uri, headers, credentials)
 
         # Perform upload of chunk.
-        response = await session.put(
-            upload_uri, data=buf, headers=headers)
-        if response.status != 200:
-            content = await response.read()
-            request = {
-                "body": buf,
-                "headers": headers,
-                "method": "PUT",
-                "uri": upload_uri,
-            }
-            raise CallError(request, response, content, None)
+        async with await session.put(
+                upload_uri, data=buf, headers=headers) as response:
+            if response.status != 200:
+                content = await response.read()
+                request = {
+                    "body": buf,
+                    "headers": headers,
+                    "method": "PUT",
+                    "uri": upload_uri,
+                }
+                raise CallError(request, response, content, None)
 
 
 class BootResources(ObjectSet, metaclass=BootResourcesType):

--- a/maas/client/viscera/testing.py
+++ b/maas/client/viscera/testing.py
@@ -9,7 +9,7 @@ from typing import Mapping
 from unittest.mock import Mock
 
 from . import OriginBase
-from ..testing import AsyncMock
+from ..testing import AsyncCallableMock
 
 
 def bind(*objects, session=None):
@@ -42,7 +42,7 @@ def bind(*objects, session=None):
     if session is None:
         session = Mock(name="session")
         session.handlers = {
-            name: AsyncMock(name="handler(%s)" % name)
+            name: AsyncCallableMock(name="handler(%s)" % name)
             for name in objects
         }
 


### PR DESCRIPTION
`AsyncAwaitableMock`, `AsyncCallableMock`, `AsyncContextMock`, and `AsyncIterableMock`. This more closely matches the different async-ish object types defined in [PEP-492](https://www.python.org/dev/peps/pep-0492).

This has been done to better test `_put_chunk`: in real use, the response was not being closed.