### PR TITLE
Start of simple non-destructive integration test suite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ upload: bin/python setup.py README
 test: bin/tox
 	@bin/tox
 
+integrate: bin/tox
+	@bin/tox -e integrate
+
 lint: bin/tox
 	@bin/tox -e lint
 
@@ -25,6 +28,7 @@ clean:
 	find . -name '*.egg-info' -print0 | xargs -r0 $(RM) -r
 	find . -name '*~' -print0 | xargs -r0 $(RM)
 	$(RM) -r .eggs .tox .coverage TAGS tags
+	$(RM) pip-selfcheck.json
 
 # ---
 
@@ -47,4 +51,4 @@ bin/mkdocs: bin/pip
 
 # ---
 
-.PHONY: develop dist docs test lint clean
+.PHONY: develop dist docs test integrate lint clean

--- a/integrate/__main__.py
+++ b/integrate/__main__.py
@@ -1,0 +1,7 @@
+import sys
+
+import testtools.run
+
+
+argv = sys.argv[0], "discover", "integrate", *sys.argv[1:]
+testtools.run.main(argv, sys.stdout)

--- a/integrate/test.py
+++ b/integrate/test.py
@@ -1,0 +1,111 @@
+"""Integration tests for `maas.client`."""
+
+from http import HTTPStatus
+import io
+from itertools import repeat
+import random
+
+from maas.client import (
+    bones,
+    viscera,
+)
+from maas.client.testing import (
+    make_name_without_spaces,
+    TestCase,
+)
+from maas.client.utils import (
+    creds,
+    profiles,
+)
+from testtools.matchers import (
+    AllMatch,
+    Equals,
+    IsInstance,
+    MatchesAll,
+    MatchesStructure,
+)
+
+
+kiB = 2 ** 10
+MiB = 2 ** 20
+
+
+def scenarios():
+    with profiles.ProfileStore.open() as config:
+        return tuple(
+            (profile.name, dict(profile=profile))
+            for profile in map(config.load, config)
+        )
+
+
+class IntegrationTestCase(TestCase):
+
+    scenarios = scenarios()
+
+    def setUp(self):
+        super(IntegrationTestCase, self).setUp()
+        self.session = bones.SessionAPI.fromProfile(self.profile)
+        self.origin = viscera.Origin(self.session)
+
+
+class TestAccount(IntegrationTestCase):
+    """Tests for module functions."""
+
+    def test__create_and_delete_credentials(self):
+        credentials = self.origin.Account.create_credentials()
+        self.assertThat(credentials, IsInstance(creds.Credentials))
+        self.origin.Account.delete_credentials(credentials)
+
+
+class TestBootResources(IntegrationTestCase):
+
+    def test__list_boot_resources(self):
+        boot_resources = self.origin.BootResources.read()
+        self.assertThat(boot_resources, MatchesAll(
+            IsInstance(self.origin.BootResources),
+            AllMatch(IsInstance(self.origin.BootResource)),
+        ))
+
+    def test__create_and_delete_boot_resource(self):
+        chunk = random.getrandbits(8 * 128).to_bytes(128, "big")
+        content = b"".join(repeat(chunk, 5 * MiB // len(chunk)))
+        boot_resource = self.origin.BootResources.create(
+            make_name_without_spaces("ubuntu", "/"), "amd64/generic",
+            io.BytesIO(content))
+        self.assertThat(boot_resource, IsInstance(self.origin.BootResource))
+        boot_resource.delete()
+        error = self.assertRaises(
+            bones.CallError,
+            self.origin.BootResource.read, boot_resource.id)
+        self.assertThat(error, MatchesStructure(
+            status=Equals(HTTPStatus.NOT_FOUND)))
+
+
+# TestBootSources
+# TestBootSourceSelections
+# TestControllers
+# TestDevices
+
+
+class TestEvents(IntegrationTestCase):
+
+    def test__query_events(self):
+        events = self.origin.Events.query()
+        self.assertThat(events, IsInstance(self.origin.Events))
+        events = events.prev()
+        self.assertThat(events, IsInstance(self.origin.Events))
+        events = events.next()
+        self.assertThat(events, IsInstance(self.origin.Events))
+
+
+# TestFiles
+# TestMAAS
+# TestMachines
+# TestTags
+# TestTesting
+# TestUsers
+# TestVersion
+# TestZones
+
+
+# End.

--- a/maas/__init__.py
+++ b/maas/__init__.py
@@ -1,2 +1,1 @@
-import pkg_resources
-pkg_resources.declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__)

--- a/maas/client/bones/__init__.py
+++ b/maas/client/bones/__init__.py
@@ -326,7 +326,7 @@ class CallError(Exception):
 
     @property
     def status(self):
-        return int(self.response["status"])
+        return self.response.status
 
 
 class CallAPI:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,15 @@ commands = coverage run setup.py test {posargs}
 sitepackages = False
 deps = coverage
 
+[testenv:integrate]
+commands = {envpython} -m integrate {posargs}
+sitepackages = False
+usedevelop = True
+deps =
+  fixtures
+  testscenarios
+  testtools
+
 [testenv:lint]
 commands = flake8 maas --isolated --ignore=E402,E123,E731
 sitepackages = False


### PR DESCRIPTION
Invoking `make integrate` will run this new test suite against each configured profile. To work with profiles, run `make develop && bin/maas profiles --help`.