### PR TITLE
helpers.py fix in newer MAAS versions to find login button

### DIFF
--- a/maas/client/bones/helpers.py
+++ b/maas/client/bones/helpers.py
@@ -223,7 +223,11 @@ async def _obtain_token(url, username, password, *, insecure=False):
 
         login_doc = bs4.BeautifulSoup(login_doc_content, "html.parser")
         login_button = login_doc.find('button', text="Login")
-        login_form = login_button.findParent("form")
+        if login_button is None:
+            login_button = login_doc.find('input', value='Login')
+            login_form = login_button.findParent("form")
+        else:
+            login_form = login_button.findParent("form")
 
         # Log-in to MAAS.
         login_data = {


### PR DESCRIPTION
calling:
profile, origin = viscera.Origin.login("http://myhost:5240/MAAS/",
                               username="myadmin",password="mypassword")



returns error:
File "/usr/local/lib/python3.5/dist-packages/maas/client/viscera/__init__.py", line 603, in login
  url=url, username=username, password=password, insecure=insecure)
File "/usr/local/lib/python3.5/dist-packages/maas/client/bones/__init__.py", line 76, in login
  url=url, username=username, password=password, insecure=insecure)
File "/usr/local/lib/python3.5/dist-packages/maas/client/utils/async.py", line 49, in wrapper
  result = eventloop.run_until_complete(result)
File "/usr/lib/python3.5/asyncio/base_events.py", line 387, in run_until_complete
  return future.result()
File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
  raise self._exception
File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
  result = coro.send(None)
File "/usr/local/lib/python3.5/dist-packages/maas/client/bones/helpers.py", line 187, in login
  url.geturl(), username, password, insecure=insecure)
File "/usr/local/lib/python3.5/dist-packages/maas/client/bones/helpers.py", line 226, in _obtain_token
  login_form = login_button.findParent("form")
AttributeError: 'NoneType' object has no attribute 'findParent'

I am trying on MAAS Version 2.1.4+bzr5591-0ubuntu1 (16.04.1)
