### PR TITLE
Test against "real" MAAS Web APIs.

### DIFF
--- a/maas/client/bones/__init__.py
+++ b/maas/client/bones/__init__.py
@@ -14,7 +14,6 @@ from collections import (
     namedtuple,
 )
 import json
-import re
 
 import aiohttp
 import aiohttp.errors
@@ -175,12 +174,7 @@ class HandlerAPI:
     @property
     def name(self):
         """A stable, human-readable name and identifier for this handler."""
-        name = self.__handler["name"]
-        if name.startswith("Anon"):
-            name = name[4:]
-        if name.endswith("Handler"):
-            name = name[:-7]
-        return re.sub('maas', 'MAAS', name, flags=re.IGNORECASE)
+        return helpers.derive_resource_name(self.__handler["name"])
 
     @property
     def uri(self):

--- a/maas/client/bones/helpers.py
+++ b/maas/client/bones/helpers.py
@@ -3,6 +3,7 @@
 __all__ = [
     "connect",
     "ConnectError",
+    "derive_resource_name",
     "fetch_api_description",
     "login",
     "LoginError",
@@ -68,6 +69,17 @@ def _ensure_url_string(url):
     else:
         raise TypeError(
             "Could not convert %r to a string URL." % (url,))
+
+
+def derive_resource_name(name):
+    """A stable, human-readable name and identifier for a resource."""
+    if name.startswith("Anon"):
+        name = name[4:]
+    if name.endswith("Handler"):
+        name = name[:-7]
+    if name == "Maas":
+        name = "MAAS"
+    return name
 
 
 class ConnectError(Exception):

--- a/maas/client/bones/testing/__init__.py
+++ b/maas/client/bones/testing/__init__.py
@@ -6,23 +6,18 @@ __all__ = [
     "list_api_descriptions",
 ]
 
-from collections import defaultdict
 import http
 import http.server
 import json
-from operator import attrgetter
 from pathlib import Path
 import re
 import threading
 
-import aiohttp.web
 import fixtures
 from pkg_resources import (
     resource_filename,
     resource_listdir,
 )
-
-from . import desc
 
 
 def list_api_descriptions():
@@ -112,124 +107,3 @@ class DescriptionServer(fixtures.Fixture):
         threading.Thread(target=self.server.serve_forever).start()
         self.addCleanup(self.server.server_close)
         self.addCleanup(self.server.shutdown)
-
-
-class Application:
-
-    def __init__(self, description):
-        super(Application, self).__init__()
-        self._description = desc.Description(description)
-        self._application = aiohttp.web.Application()
-
-    def resolve(self, action):
-        match = re.match(r"^(anon|auth):(\w+[.]\w+)$", action)
-        if match is None:
-            raise ValueError(
-                "Action should be (anon|auth):Resource.action, got: %s"
-                % (action,))
-        else:
-            anon_auth, resource_name = match.groups()
-            resources = getattr(self._description, anon_auth)
-            try:
-                action = attrgetter(resource_name)(resources)
-            except AttributeError:
-                raise ValueError("%s not found." % resource_name)
-            else:
-                return action
-
-    def handle(self, action_name, handler):
-        action = self.resolve(action_name)
-        self._application.router.add_route(
-            action.method, action.path, handler, name=action_name)
-
-    def describe(self):
-        actions = [
-            self.resolve(route.name)
-            for route in self._application.router.routes()
-            if route.name is not None
-        ]
-
-        by_resource = defaultdict(list)
-        for action in actions:
-            by_resource[action.resource].append(action)
-
-        by_resource_name = defaultdict(dict)
-        for resource, actions in by_resource.items():
-            res_name = resource["name"]
-            res_name_raw = resource["raw-name"]
-            res_desc = by_resource_name[res_name]
-
-            if "names" in res_desc:
-                res_desc["names"].add(res_name_raw)
-            else:
-                res_desc["names"] = {res_name_raw}
-
-            assert res_desc.setdefault("name", res_name) == res_name
-            anon_auth = "anon" if resource["is_anonymous"] else "auth"
-            assert anon_auth not in res_desc
-            res_desc[anon_auth] = {
-                "actions": [
-                    {
-                        "doc": action.doc.title,  # Just the title.
-                        "method": action.method,
-                        "name": action.name,
-                        "op": action.op,
-                        "restful": action.is_restful,
-                    }
-                    for action in actions
-                ],
-                "doc": resource["doc"].title,
-                "name": resource["raw-name"],
-                "params": resource["params"],
-                "path": resource["path"],
-                "uri": resource["uri"],
-            }
-
-        for res_desc in by_resource_name.values():
-            res_names = res_desc.pop("names")
-            res_desc["name"] = min(res_names, key=len)
-
-        return {
-            "doc": self._description.doc.title,
-            "hash": "// not calculated //",
-            "resources": list(by_resource_name.values()),
-        }
-
-
-api20 = api_descriptions[0][1]
-app = Application(api20)
-app.handle("auth:Machines.allocate", print)
-app.handle("auth:Machines.accept", print)
-app.handle("anon:Machines.accept", print)
-app.handle("anon:Version.read", print)
-
-# print(json.dumps(app.describe(), sort_keys=True, indent="  "))
-
-
-{
-    'anon': None,
-    'auth': {
-        'actions': [
-            {
-                'doc': "...",
-                'method': 'GET',
-                'name': 'read',
-                'op': None,
-                'restful': True,
-            },
-            {
-                'doc': "...",
-                'method': 'POST',
-                'name': 'create',
-                'op': None,
-                'restful': True,
-            },
-        ],
-        'doc': 'Manage block devices on a node.',
-        'name': 'BlockDevicesHandler',
-        'params': ['system_id'],
-        'path': '/MAAS/api/2.0/nodes/{system_id}/blockdevices/',
-        'uri': 'http://srv:5240/MAAS/api/2.0/nodes/{system_id}/blockdevices/',
-    },
-    'name': 'BlockDevicesHandler',
-}

--- a/maas/client/bones/testing/__init__.py
+++ b/maas/client/bones/testing/__init__.py
@@ -6,18 +6,23 @@ __all__ = [
     "list_api_descriptions",
 ]
 
+from collections import defaultdict
 import http
 import http.server
 import json
+from operator import attrgetter
 from pathlib import Path
 import re
 import threading
 
+import aiohttp.web
 import fixtures
 from pkg_resources import (
     resource_filename,
     resource_listdir,
 )
+
+from . import desc
 
 
 def list_api_descriptions():
@@ -107,3 +112,124 @@ class DescriptionServer(fixtures.Fixture):
         threading.Thread(target=self.server.serve_forever).start()
         self.addCleanup(self.server.server_close)
         self.addCleanup(self.server.shutdown)
+
+
+class Application:
+
+    def __init__(self, description):
+        super(Application, self).__init__()
+        self._description = desc.Description(description)
+        self._application = aiohttp.web.Application()
+
+    def resolve(self, action):
+        match = re.match(r"^(anon|auth):(\w+[.]\w+)$", action)
+        if match is None:
+            raise ValueError(
+                "Action should be (anon|auth):Resource.action, got: %s"
+                % (action,))
+        else:
+            anon_auth, resource_name = match.groups()
+            resources = getattr(self._description, anon_auth)
+            try:
+                action = attrgetter(resource_name)(resources)
+            except AttributeError:
+                raise ValueError("%s not found." % resource_name)
+            else:
+                return action
+
+    def handle(self, action_name, handler):
+        action = self.resolve(action_name)
+        self._application.router.add_route(
+            action.method, action.path, handler, name=action_name)
+
+    def describe(self):
+        actions = [
+            self.resolve(route.name)
+            for route in self._application.router.routes()
+            if route.name is not None
+        ]
+
+        by_resource = defaultdict(list)
+        for action in actions:
+            by_resource[action.resource].append(action)
+
+        by_resource_name = defaultdict(dict)
+        for resource, actions in by_resource.items():
+            res_name = resource["name"]
+            res_name_raw = resource["raw-name"]
+            res_desc = by_resource_name[res_name]
+
+            if "names" in res_desc:
+                res_desc["names"].add(res_name_raw)
+            else:
+                res_desc["names"] = {res_name_raw}
+
+            assert res_desc.setdefault("name", res_name) == res_name
+            anon_auth = "anon" if resource["is_anonymous"] else "auth"
+            assert anon_auth not in res_desc
+            res_desc[anon_auth] = {
+                "actions": [
+                    {
+                        "doc": action.doc.title,  # Just the title.
+                        "method": action.method,
+                        "name": action.name,
+                        "op": action.op,
+                        "restful": action.is_restful,
+                    }
+                    for action in actions
+                ],
+                "doc": resource["doc"].title,
+                "name": resource["raw-name"],
+                "params": resource["params"],
+                "path": resource["path"],
+                "uri": resource["uri"],
+            }
+
+        for res_desc in by_resource_name.values():
+            res_names = res_desc.pop("names")
+            res_desc["name"] = min(res_names, key=len)
+
+        return {
+            "doc": self._description.doc.title,
+            "hash": "// not calculated //",
+            "resources": list(by_resource_name.values()),
+        }
+
+
+api20 = api_descriptions[0][1]
+app = Application(api20)
+app.handle("auth:Machines.allocate", print)
+app.handle("auth:Machines.accept", print)
+app.handle("anon:Machines.accept", print)
+app.handle("anon:Version.read", print)
+
+# print(json.dumps(app.describe(), sort_keys=True, indent="  "))
+
+
+{
+    'anon': None,
+    'auth': {
+        'actions': [
+            {
+                'doc': "...",
+                'method': 'GET',
+                'name': 'read',
+                'op': None,
+                'restful': True,
+            },
+            {
+                'doc': "...",
+                'method': 'POST',
+                'name': 'create',
+                'op': None,
+                'restful': True,
+            },
+        ],
+        'doc': 'Manage block devices on a node.',
+        'name': 'BlockDevicesHandler',
+        'params': ['system_id'],
+        'path': '/MAAS/api/2.0/nodes/{system_id}/blockdevices/',
+        'uri': 'http://srv:5240/MAAS/api/2.0/nodes/{system_id}/blockdevices/',
+    },
+    'name': 'BlockDevicesHandler',
+}

--- a/maas/client/bones/testing/__init__.py
+++ b/maas/client/bones/testing/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
 import http
 import http.server
 import json
+from operator import itemgetter
 from pathlib import Path
 import re
 import threading
@@ -43,7 +44,7 @@ def load_api_descriptions():
         yield name, version, json.loads(description)
 
 
-api_descriptions = list(load_api_descriptions())
+api_descriptions = sorted(load_api_descriptions(), key=itemgetter(1))
 assert len(api_descriptions) != 0
 
 

--- a/maas/client/bones/testing/desc.py
+++ b/maas/client/bones/testing/desc.py
@@ -78,9 +78,26 @@ class Resource:
             name = "%s_" % name if iskeyword(name) else name
             setattr(self, name, Action(self, action))
 
+    def __getitem__(self, name):
+        if name in {"path", "uri"}:
+            return self._data[name]
+        elif name == "raw-name":
+            return self._data["name"]
+        elif name == "name":
+            return self._name
+        elif name == "doc":
+            doc = self._data["doc"]
+            return parse_docstring(doc)
+        elif name == "params":
+            params = self._data[name]
+            return tuple(params)
+        elif name == "is_anonymous":
+            return self._anonymous
+        else:
+            raise KeyError(name)
+
     def __repr__(self):
-        doc = self._data["doc"]
-        title, body = parse_docstring(doc)
+        title, body = self["doc"]
         return "<%s:%s %r>" % (
             self.__class__.__name__,
             self._name, title.rstrip("."),
@@ -98,20 +115,24 @@ class Action:
     # Resource-specific properties.
 
     @property
+    def resource(self):
+        return self._resource
+
+    @property
     def is_anonymous(self):
-        return self._resource._anonymous
+        return self._resource["is_anonymous"]
 
     @property
     def params(self):
-        return frozenset(self._resource._data["params"])
+        return self._resource["params"]
 
     @property
     def path(self):
-        return self._resource._data["path"]
+        return self._resource["path"]
 
     @property
     def uri(self):
-        return self._resource._data["uri"]
+        return self._resource["uri"]
 
     # Action-specific properties.
 

--- a/maas/client/bones/testing/desc.py
+++ b/maas/client/bones/testing/desc.py
@@ -1,0 +1,147 @@
+"""Abstractions around API description documents."""
+
+__all__ = [
+    "Description",
+    "Action",
+]
+
+from keyword import iskeyword
+from operator import itemgetter
+
+from maas.client.bones.helpers import derive_resource_name
+from maas.client.utils import parse_docstring
+
+
+class Description:
+    """Object-oriented interface to a MAAS API description document."""
+
+    def __init__(self, description):
+        super(Description, self).__init__()
+        self._description = description
+        self._populate()
+
+    def _populate(self):
+        self.anon = Resources(True, self._resources("anon"))
+        self.auth = Resources(False, self._resources("auth"))
+
+    def _resources(self, classification):
+        resources = self._description["resources"]
+        resources = map(itemgetter(classification), resources)
+        return (rs for rs in resources if rs is not None)
+
+    @property
+    def doc(self):
+        doc = self._description["doc"]
+        return parse_docstring(doc)
+
+    @property
+    def hash(self):
+        return self._description["hash"]
+
+    @property
+    def raw(self):
+        return self._description
+
+    def __repr__(self):
+        title, body = self.doc
+        return "<%s %r %s>" % (
+            self.__class__.__name__,
+            title.rstrip("."), self.hash,
+        )
+
+
+class Resources:
+    """Pincushion of API resources."""
+
+    def __init__(self, anonymous, resources):
+        super(Resources, self).__init__()
+        for resource in resources:
+            name = derive_resource_name(resource["name"])
+            resource = Resource(name, anonymous, resource)
+            attrname = "%s_" % name if iskeyword(name) else name
+            setattr(self, attrname, resource)
+
+
+class Resource:
+    """An API resource, like `Machines`."""
+
+    def __init__(self, name, anonymous, data):
+        super(Resource, self).__init__()
+        self._name = name
+        self._anonymous = anonymous
+        self._data = data
+        self._populate()
+
+    def _populate(self):
+        for action in self._data["actions"]:
+            name = action["name"]
+            name = "%s_" % name if iskeyword(name) else name
+            setattr(self, name, Action(self, action))
+
+    def __repr__(self):
+        doc = self._data["doc"]
+        title, body = parse_docstring(doc)
+        return "<%s:%s %r>" % (
+            self.__class__.__name__,
+            self._name, title.rstrip("."),
+        )
+
+
+class Action:
+    """An API action on a resource, like `Machines.allocate`."""
+
+    def __init__(self, resource, data):
+        super(Action, self).__init__()
+        self._resource = resource
+        self._data = data
+
+    # Resource-specific properties.
+
+    @property
+    def is_anonymous(self):
+        return self._resource._anonymous
+
+    @property
+    def params(self):
+        return frozenset(self._resource._data["params"])
+
+    @property
+    def path(self):
+        return self._resource._data["path"]
+
+    @property
+    def uri(self):
+        return self._resource._data["uri"]
+
+    # Action-specific properties.
+
+    @property
+    def doc(self):
+        doc = self._data["doc"]
+        return parse_docstring(doc)
+
+    @property
+    def method(self):
+        return self._data["method"]
+
+    @property
+    def name(self):
+        return self._data["name"]
+
+    @property
+    def op(self):
+        return self._data["op"]
+
+    @property
+    def is_restful(self):
+        return self._data["restful"]
+
+    # Other.
+
+    def __repr__(self):
+        title, body = self.doc
+        return "<%s:%s.%s %r %s %s%s>" % (
+            self.__class__.__name__, self._resource._name,
+            self.name, title.rstrip("."), self.method, self.path,
+            ("" if self.op is None else "?op=" + self.op)
+        )

--- a/maas/client/bones/testing/server.py
+++ b/maas/client/bones/testing/server.py
@@ -1,0 +1,172 @@
+"""Testing server."""
+
+__all__ = [
+    "ApplicationServer",
+]
+
+from collections import defaultdict
+import json
+from operator import attrgetter
+import re
+from urllib.parse import urlparse
+
+import aiohttp.web
+
+from . import desc
+
+
+class ApplicationServer:
+
+    def __init__(self, description):
+        super(ApplicationServer, self).__init__()
+        self._description = desc.Description(description)
+        self._application = aiohttp.web.Application()
+        self._basepath, self._version = self._discover_version_and_base_path()
+        self._wire_up_description()
+        self._actions = {}
+        self._views = {}
+
+    def handle(self, action_name, handler):
+        action = self._resolve_action(action_name)
+        view_name = self._view_name(action)
+        assert view_name not in self._actions
+        self._actions[view_name] = action
+        if view_name in self._views:
+            view = self._views[view_name]
+            view.set(action, handler)
+        else:
+            view = self._views[view_name] = ApplicationView()
+            self._application.router.add_route("*", action.path, view)
+            view.set(action, handler)
+
+    def serve(self):
+        aiohttp.web.run_app(self._application)
+
+    @staticmethod
+    def _view_name(action):
+        return "%s.%s" % (action.resource["name"], action.name)
+
+    def _discover_version_and_base_path(self):
+        for resource in self._description:
+            path = urlparse(resource["uri"]).path
+            match = re.match("(.*/api/([0-9.]+))/", path)
+            if match is not None:
+                base, version = match.groups()
+                return base, version
+        else:
+            raise ValueError(
+                "Could not discover version or base path.")
+
+    def _wire_up_description(self):
+        path = "%s/describe" % self._basepath
+
+        def describe(request):
+            description = self._render_description(
+                request.url.with_path(""))
+            description_json = json.dumps(
+                description, indent="  ", sort_keys=True)
+            return aiohttp.web.Response(
+                text=description_json, content_type="application/json")
+
+        self._application.router.add_get(path, describe)
+
+    def _render_description(self, base):
+        by_resource = defaultdict(list)
+        for action in self._actions.values():
+            by_resource[action.resource].append(action)
+
+        by_resource_name = defaultdict(dict)
+        for resource, actions in by_resource.items():
+            res_name = resource["name"]
+            res_name_raw = resource["name/raw"]
+            res_desc = by_resource_name[res_name]
+
+            if "names" in res_desc:
+                res_desc["names"].add(res_name_raw)
+            else:
+                res_desc["names"] = {res_name_raw}
+
+            assert res_desc.setdefault("name", res_name) == res_name
+            anon_auth = "anon" if resource["is_anonymous"] else "auth"
+            assert anon_auth not in res_desc
+            res_desc[anon_auth] = {
+                "actions": [
+                    {
+                        "doc": action.doc.title,  # Just the title.
+                        "method": action.method,
+                        "name": action.name,
+                        "op": action.op,
+                        "restful": action.is_restful,
+                    }
+                    for action in actions
+                ],
+                "doc": resource["doc"].title,
+                "name": resource["name/raw"],
+                "params": resource["params"],
+                "path": resource["path"],
+                "uri": str(base) + resource["path"],
+            }
+
+        for res_desc in by_resource_name.values():
+            res_names = res_desc.pop("names")
+            res_desc["name"] = min(res_names, key=len)
+
+        return {
+            "doc": self._description.doc.title,
+            "hash": "// not calculated //",
+            "resources": list(by_resource_name.values()),
+        }
+
+    def _resolve_action(self, action_name):
+        match = re.match(r"^(anon|auth):(\w+[.]\w+)$", action_name)
+        if match is None:
+            raise ValueError(
+                "Action should be (anon|auth):Resource.action, got: %s"
+                % (action_name,))
+        else:
+            anon_auth, resource_name = match.groups()
+            resources = getattr(self._description, anon_auth)
+            try:
+                action = attrgetter(resource_name)(resources)
+            except AttributeError:
+                raise ValueError("%s not found." % resource_name)
+            else:
+                assert action.action_name == action_name
+                return action
+
+
+class ApplicationView:
+
+    def __init__(self):
+        super(ApplicationView, self).__init__()
+        self.rest, self.ops = {}, {}
+
+    @property
+    def allowed_methods(self):
+        allowed_methods = frozenset(self.rest)
+        if len(self.ops) == 0:
+            return allowed_methods
+        else:
+            return allowed_methods | {aiohttp.hdrs.METH_POST}
+
+    def set(self, action, handler):
+        if action.is_restful:
+            self.rest[action.method] = handler
+        else:
+            self.ops[action.op] = handler
+
+    async def __call__(self, request):
+        if request.method == "POST":
+            op = request.rel_url.query.get("op")
+            if op is None:
+                handler = self.rest.get(request.method)
+            else:
+                handler = self.ops.get(op)
+        else:
+            handler = self.rest.get(request.method)
+
+        if handler is None:
+            raise aiohttp.web.HTTPMethodNotAllowed(
+                request.method, self.allowed_methods)
+        else:
+            return handler(request)

--- a/maas/client/bones/tests/test_helpers.py
+++ b/maas/client/bones/tests/test_helpers.py
@@ -266,3 +266,27 @@ class TestLogin(TestCase):
         helpers.login("http://:@maas.io/")
         helpers._obtain_token.assert_called_once_with(
             "http://maas.io/api/2.0/", "", "", insecure=False)
+
+
+class TestDeriveResourceName(TestCase):
+    """Tests for `derive_resource_name`."""
+
+    def test__removes_Anon_prefix(self):
+        self.assertThat(
+            helpers.derive_resource_name("AnonFooBar"),
+            Equals("FooBar"))
+
+    def test__removes_Handler_suffix(self):
+        self.assertThat(
+            helpers.derive_resource_name("FooBarHandler"),
+            Equals("FooBar"))
+
+    def test__normalises_Maas_to_MAAS(self):
+        self.assertThat(
+            helpers.derive_resource_name("Maas"),
+            Equals("MAAS"))
+
+    def test__does_all_the_above(self):
+        self.assertThat(
+            helpers.derive_resource_name("AnonMaasHandler"),
+            Equals("MAAS"))

--- a/maas/client/testing.py
+++ b/maas/client/testing.py
@@ -33,6 +33,8 @@ import testscenarios
 from testtools import testcase
 from testtools.matchers import DocTestMatches
 
+from .utils.async import Asynchronous
+
 
 random_letters = map(
     random.choice, repeat(string.ascii_letters + string.digits))
@@ -111,7 +113,13 @@ class WithScenarios(testscenarios.WithScenarios):
             super(WithScenarios, self).__call__(result)
 
 
-class TestCase(WithScenarios, testcase.TestCase):
+class TestCase(WithScenarios, testcase.TestCase, metaclass=Asynchronous):
+    """Base test case class for all of python-libmaas.
+
+    This creates a new `asyncio` event loop for every test, and tears it down
+    afterwards. It transparently copes with asynchronous test methods and
+    other test methods by running them in this freshly created loop.
+    """
 
     def setUp(self):
         super(TestCase, self).setUp()

--- a/maas/client/utils/__init__.py
+++ b/maas/client/utils/__init__.py
@@ -12,7 +12,10 @@ __all__ = [
     "vars_class",
 ]
 
-from collections import Iterable
+from collections import (
+    Iterable,
+    namedtuple,
+)
 from functools import (
     lru_cache,
     partial,
@@ -170,6 +173,9 @@ newline = "\n"
 empty = ""
 
 
+docstring = namedtuple("docstring", ("title", "body"))
+
+
 @lru_cache(2**10)
 def parse_docstring(thing):
     """Parse a Python docstring, or the docstring found on `thing`.
@@ -191,7 +197,7 @@ def parse_docstring(thing):
     title = remove_line_breaks(title)
     # Normalise line-breaks on newline.
     body = body.replace("\r\n", newline).replace("\r", newline)
-    return title, body
+    return docstring(title, body)
 
 
 def ensure_trailing_slash(string):

--- a/maas/client/utils/tests/test.py
+++ b/maas/client/utils/tests/test.py
@@ -12,6 +12,7 @@ from testtools.matchers import (
     Equals,
     Is,
     MatchesListwise,
+    MatchesStructure,
 )
 from twisted.internet.task import Clock
 
@@ -240,26 +241,27 @@ class TestPayloadPreparationWithFiles(TestCase):
 class TestDocstringParsing(TestCase):
     """Tests for docstring parsing with `parse_docstring`."""
 
-    scenarios = (
-        ("normal", dict(parse=utils.parse_docstring)),
-    )
-
     def test_basic(self):
         self.assertEqual(
             ("Title", "Body"),
-            self.parse("Title\n\nBody"))
+            utils.parse_docstring("Title\n\nBody"))
         self.assertEqual(
             ("A longer title", "A longer body"),
-            self.parse("A longer title\n\nA longer body"))
+            utils.parse_docstring("A longer title\n\nA longer body"))
+
+    def test_returns_named_tuple(self):
+        self.assertThat(
+            utils.parse_docstring("Title\n\nBody"),
+            MatchesStructure.byEquality(title="Title", body="Body"))
 
     def test_no_body(self):
         # parse_docstring returns an empty string when there's no body.
         self.assertEqual(
             ("Title", ""),
-            self.parse("Title\n\n"))
+            utils.parse_docstring("Title\n\n"))
         self.assertEqual(
             ("Title", ""),
-            self.parse("Title"))
+            utils.parse_docstring("Title"))
 
     def test_unwrapping(self):
         # parse_docstring unwraps the title paragraph, and dedents the body
@@ -268,7 +270,7 @@ class TestDocstringParsing(TestCase):
             ("Title over two lines",
              "Paragraph over\ntwo lines\n\n"
              "Another paragraph\nover two lines"),
-            self.parse("""
+            utils.parse_docstring("""
                 Title over
                 two lines
 
@@ -289,17 +291,17 @@ class TestDocstringParsing(TestCase):
             """
         self.assertEqual(
             ("Title.", "Body."),
-            self.parse(example))
+            utils.parse_docstring(example))
 
     def test_normalises_whitespace(self):
         # parse_docstring can parse CRLF/CR/LF text, but always emits LF (\n,
         # new-line) separated text.
         self.assertEqual(
             ("long title", ""),
-            self.parse("long\r\ntitle"))
+            utils.parse_docstring("long\r\ntitle"))
         self.assertEqual(
             ("title", "body1\n\nbody2"),
-            self.parse("title\n\nbody1\r\rbody2"))
+            utils.parse_docstring("title\n\nbody1\r\rbody2"))
 
 
 class TestFunctions(TestCase):


### PR DESCRIPTION
This introduces a "real" web application against which to test. It is constructed from an API description document and so only endpoints that exist in a particular version can be created at test time. Test authors must still provide implementations of those endpoints (or, more likely, canned output) but this is already a big step towards ensuring that python-libmaas can work with multiple versions of the MAAS API.

This code is still a bit rough, but it will be iterated upon actively; I want to get this landed now so I can reference it in developer documentation.