### PR TITLE
Machines power parameters

### DIFF
--- a/maas/client/facade.py
+++ b/maas/client/facade.py
@@ -139,7 +139,7 @@ class Client:
             "allocate": origin.Machines.allocate,
             "get": origin.Machine.read,
             "list": origin.Machines.read,
-            "power_parameters": origin.Machines.power_parameters,
+            "get_power_parameters": origin.Machines.get_power_parameters,
         }
 
     @facade

--- a/maas/client/facade.py
+++ b/maas/client/facade.py
@@ -139,6 +139,7 @@ class Client:
             "allocate": origin.Machines.allocate,
             "get": origin.Machine.read,
             "list": origin.Machines.read,
+            "power_parameters": origin.Machines.power_parameters,
         }
 
     @facade

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -67,15 +67,13 @@ class MachinesType(ObjectType):
         else:
             return cls._object(data)
 
-    async def power_parameters(cls, *, system_ids: typing.Sequence[str]=None):
+    async def power_parameters(
+            cls, *, system_ids: typing.Sequence[str]=[]):
         """
         :param system_ids: The system IDs to get power parameters for
         """
-        params = {}
-        if system_ids is not None:
-            params["id"] = system_ids
-        data = await cls.handler.power_parameters(**params)
-        return cls._object(data)
+        data = await cls._handler.power_parameters(id=system_ids)
+        return data
 
 
 class MachineNotFound(Exception):

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -67,6 +67,16 @@ class MachinesType(ObjectType):
         else:
             return cls._object(data)
 
+    async def power_parameters(cls, *, system_ids: typing.Sequence[str]=None):
+        """
+        :param system_ids: The system IDs to get power parameters for
+        """
+        params = {}
+        if system_ids is not None:
+            params["id"] = system_ids
+        data = await cls.handler.power_parameters(**params)
+        return cls._object(data)
+
 
 class MachineNotFound(Exception):
     """Machine was not found."""

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -67,7 +67,7 @@ class MachinesType(ObjectType):
         else:
             return cls._object(data)
 
-    async def power_parameters(
+    async def get_power_parameters(
             cls, *, system_ids: typing.Sequence[str]=[]):
         """
         :param system_ids: The system IDs to get power parameters for

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -93,6 +93,8 @@ class TestMachines(TestCase):
             not_tags=['baz'],
         )
 
-    def test_power_parameters(self):
+    def test__power_parameters(self):
         Machines = make_origin().Machines
         Machines._handler.power_parameters.return_value = {}
+        Machines.power_parameters()
+        Machines._handler.power_parameters.assert_called_once_with(id=[])

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -93,8 +93,33 @@ class TestMachines(TestCase):
             not_tags=['baz'],
         )
 
-    def test__power_parameters(self):
+    def test__get_power_parameters(self):
+        power_parameters = {
+            make_name_without_spaces("system_id"): {
+                "key": make_name_without_spaces("value")
+            }
+        }
         Machines = make_origin().Machines
-        Machines._handler.power_parameters.return_value = {}
-        Machines.power_parameters()
+        Machines._handler.power_parameters.return_value = power_parameters
+        self.assertThat(
+            Machines.get_power_parameters(),
+            Equals(power_parameters)
+        )
         Machines._handler.power_parameters.assert_called_once_with(id=[])
+
+    def test__get_power_parameters_with_system_ids(self):
+        power_parameters = {
+            make_name_without_spaces("system_id"): {
+                "key": make_name_without_spaces("value")
+            }
+            for _ in range(3)
+        }
+        Machines = make_origin().Machines
+        Machines._handler.power_parameters.return_value = power_parameters
+        self.assertThat(
+            Machines.get_power_parameters(system_ids=power_parameters.keys()),
+            Equals(power_parameters)
+        )
+        Machines._handler.power_parameters.assert_called_once_with(
+            id=power_parameters.keys()
+        )

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -92,3 +92,7 @@ class TestMachines(TestCase):
             tags=['foo', 'bar'],
             not_tags=['baz'],
         )
+
+    def test_power_parameters(self):
+        Machines = make_origin().Machines
+        Machines._handler.power_parameters.return_value = {}


### PR DESCRIPTION
In response to issue #81, I have added a method to the Machines object to query power parameters. By default it gets them for all machines, but can be filtered by system ID as well.