### PR TITLE
Authenticate to API.

### DIFF
--- a/maas/client/testing.py
+++ b/maas/client/testing.py
@@ -171,20 +171,16 @@ class TestCase(WithScenarios, testcase.TestCase, metaclass=Asynchronous):
     def patch(self, obj, attribute, value=mock.sentinel.unset):
         """Patch `obj.attribute` with `value`.
 
-        If `value` is unspecified, a new `MagicMock` will be created and
-        patched-in instead. Its ``__name__`` attribute will be set to
-        `attribute` or the ``__name__`` of the replaced object if `attribute`
-        is not given.
+        If `value` is unspecified, a new `Mock` will be created and patched-in
+        instead. Its ``__name__`` attribute will be set to `attribute`.
 
         This is a thin customisation of `testtools.TestCase.patch`, so refer
         to that in case of doubt.
 
         :return: The patched-in object.
         """
-        if isinstance(attribute, bytes):
-            attribute = attribute.decode("ascii")
         if value is mock.sentinel.unset:
-            value = mock.MagicMock(__name__=attribute)
+            value = mock.Mock(__name__=attribute)
         super(TestCase, self).patch(obj, attribute, value)
         return value
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     install_requires={
         "aiohttp >= 1.1.4",
         "argcomplete >= 1.0",
-        "beautifulsoup4 >= 4.4.1",
         "colorclass >= 1.2.0",
         "oauthlib >= 1.0.3",
         "pytz >= 2014.10",


### PR DESCRIPTION
This uses the [new as-yet-unreleased `/accounts/authenticate/` endpoint](https://code.launchpad.net/~allenap/maas/authenticate-to-api/+merge/319868) to get an API token instead of scraping the log-in page, which was proving fairly unreliable.

It also improves the in-process test server, including adding many docstrings.