### PR TITLE
Insist on aiohttp 2.0.0 or later.

### DIFF
--- a/maas/client/bones/__init__.py
+++ b/maas/client/bones/__init__.py
@@ -16,7 +16,6 @@ from collections import (
 import json
 
 import aiohttp
-import aiohttp.errors
 
 from . import helpers
 from .. import utils

--- a/maas/client/bones/helpers.py
+++ b/maas/client/bones/helpers.py
@@ -26,7 +26,6 @@ from urllib.parse import (
 )
 
 import aiohttp
-import aiohttp.errors
 
 from ..utils import api_url
 from ..utils.async import asynchronous

--- a/maas/client/bones/testing/server.py
+++ b/maas/client/bones/testing/server.py
@@ -4,6 +4,7 @@ __all__ = [
     "ApplicationBuilder",
 ]
 
+import asyncio
 from collections import defaultdict
 from functools import partial
 import json
@@ -295,11 +296,12 @@ class ApplicationRunner:
     def __init__(self, application, basepath):
         super(ApplicationRunner, self).__init__()
         self._application = application
-        self._loop = application.loop
         self._basepath = basepath
 
     async def __aenter__(self):
-        self._handler = self._application.make_handler()
+        self._loop = asyncio.get_event_loop()
+        self._handler = self._application.make_handler(loop=self._loop)
+        await self._application.startup()
         self._server = await self._loop.create_server(
             self._handler, host="0.0.0.0", port=0)
         return "http://%s:%d/%s/" % (

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'maas.client.bones.testing': ['*.json'],
     },
     install_requires={
-        "aiohttp >= 1.1.4",
+        "aiohttp >= 2.0.0",
         "argcomplete >= 1.0",
         "colorclass >= 1.2.0",
         "oauthlib >= 1.0.3",


### PR DESCRIPTION
aiohttp 2.0.0 has been released to PyPI. It has some breaking changes that affect python-libmaas. This fixes those incompatibilities and also pins aiohttp at 2.0.0 or later.

Fixes #95.