### PR TITLE
Rescue mode methods (and async deploy/release)

### DIFF
--- a/maas/client/enum.py
+++ b/maas/client/enum.py
@@ -1,0 +1,59 @@
+__all__ = [
+    "NodeStatus",
+]
+
+import enum
+
+
+class NodeStatus(enum.IntEnum):
+    #: A node starts out as NEW (DEFAULT is an alias for NEW).
+    DEFAULT = 0
+    #: The node has been created and has a system ID assigned to it.
+    NEW = 0
+    #: Testing and other commissioning steps are taking place.
+    COMMISSIONING = 1
+    #: The commissioning step failed.
+    FAILED_COMMISSIONING = 2
+    #: The node can't be contacted.
+    MISSING = 3
+    #: The node is in the general pool ready to be deployed.
+    READY = 4
+    #: The node is ready for named deployment.
+    RESERVED = 5
+    #: The node has booted into the operating system of its owner's choice
+    #: and is ready for use.
+    DEPLOYED = 6
+    #: The node has been removed from service manually until an admin
+    #: overrides the retirement.
+    RETIRED = 7
+    #: The node is broken: a step in the node lifecyle failed.
+    #: More details can be found in the node's event log.
+    BROKEN = 8
+    #: The node is being installed.
+    DEPLOYING = 9
+    #: The node has been allocated to a user and is ready for deployment.
+    ALLOCATED = 10
+    #: The deployment of the node failed.
+    FAILED_DEPLOYMENT = 11
+    #: The node is powering down after a release request.
+    RELEASING = 12
+    #: The releasing of the node failed.
+    FAILED_RELEASING = 13
+    #: The node is erasing its disks.
+    DISK_ERASING = 14
+    #: The node failed to erase its disks.
+    FAILED_DISK_ERASING = 15
+    #: The node is in rescue mode.
+    RESCUE_MODE = 16
+    #: The node is entering rescue mode.
+    ENTERING_RESCUE_MODE = 17
+    #: The node failed to enter rescue mode.
+    FAILED_ENTERING_RESCUE_MODE = 18
+    #: The node is exiting rescue mode.
+    EXITING_RESCUE_MODE = 19
+    #: The node failed to exit rescue mode.
+    FAILED_EXITING_RESCUE_MODE = 20
+    #: Running tests on Node
+    TESTING = 21
+    #: Testing has failed
+    FAILED_TESTING = 22

--- a/maas/client/errors.py
+++ b/maas/client/errors.py
@@ -1,0 +1,9 @@
+""" Custom errors for libmaas """
+
+__all__ = [
+    "OperationNotAllowed"
+]
+
+
+class OperationNotAllowed(Exception):
+    """ MAAS says this operation cannot be performed. """

--- a/maas/client/errors.py
+++ b/maas/client/errors.py
@@ -1,8 +1,16 @@
 """ Custom errors for libmaas """
 
 __all__ = [
+    "MAASException",
     "OperationNotAllowed"
 ]
+
+
+class MAASException(Exception):
+
+    def __init__(self, msg, obj):
+        super().__init__(msg)
+        self.obj = obj
 
 
 class OperationNotAllowed(Exception):

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -89,6 +89,14 @@ class MachineNotFound(Exception):
     """Machine was not found."""
 
 
+class RescueModeFailure(Exception):
+    """Machine failed to perform a Rescue mode transition."""
+
+
+class FailedDeployment(Exception):
+    """Machine failed to Deploy."""
+
+
 class Machines(ObjectSet, metaclass=MachinesType):
     """The set of machines stored in MAAS."""
 
@@ -205,6 +213,11 @@ class Machine(Object, metaclass=MachineType):
                 await asyncio.sleep(wait)
                 data = await self._handler.read(system_id=self.system_id)
                 machine = type(self)(data)
+            if machine.status == NodeStatus.FAILED_DEPLOYMENT:
+                msg = "{system_id} failed to Deploy.".format(
+                    system_id=machine.system_id
+                )
+                raise FailedDeployment(msg)
             return machine
 
     async def get_power_parameters(self):
@@ -249,6 +262,11 @@ class Machine(Object, metaclass=MachineType):
                 await asyncio.sleep(wait)
                 data = await self._handler.read(system_id=self.system_id)
                 machine = type(self)(data)
+            if machine.status == NodeStatus.FAILED_ENTERING_RESCUE_MODE:
+                msg = "{system_id} failed to enter Rescue Mode.".format(
+                    system_id=machine.system_id
+                )
+                raise RescueModeFailure(msg)
             return machine
 
     async def exit_rescue_mode(self, wait: int=None):
@@ -274,6 +292,11 @@ class Machine(Object, metaclass=MachineType):
                 await asyncio.sleep(wait)
                 data = await self._handler.read(system_id=self.system_id)
                 machine = type(self)(data)
+            if machine.status == NodeStatus.FAILED_EXITING_RESCUE_MODE:
+                msg = "{system_id} failed to exit Rescue Mode.".format(
+                    system_id=machine.system_id
+                )
+                raise RescueModeFailure(msg)
             return machine
 
     def __repr__(self):

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -274,6 +274,24 @@ class TestMachine(TestCase):
             system_id=machine.system_id
         )
 
+    def test__release_with_wait_failed(self):
+        system_id = make_name_without_spaces("system-id")
+        hostname = make_name_without_spaces("hostname")
+        data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.RELEASING,
+        }
+        failed_release_data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.FAILED_RELEASING,
+        }
+        machine = make_origin().Machine(data)
+        machine._handler.release.return_value = data
+        machine._handler.read.return_value = failed_release_data
+        self.assertRaises(machines.FailedReleasing, machine.release, wait=0.1)
+
 
 class TestMachine_APIVersion(TestCase):
 

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -64,6 +64,24 @@ class TestMachine(TestCase):
             system_id=machine.system_id
         )
 
+    def test__deploy_with_wait_failed(self):
+        system_id = make_name_without_spaces("system-id")
+        hostname = make_name_without_spaces("hostname")
+        data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.DEPLOYING,
+        }
+        failed_deploy_data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.FAILED_DEPLOYMENT,
+        }
+        machine = make_origin().Machine(data)
+        machine._handler.deploy.return_value = data
+        machine._handler.read.return_value = failed_deploy_data
+        self.assertRaises(machines.FailedDeployment, machine.deploy, wait=0.1)
+
     def test__get_power_parameters(self):
         machine = make_origin().Machine({
             "system_id": make_name_without_spaces("system-id"),
@@ -136,6 +154,27 @@ class TestMachine(TestCase):
             system_id=rm_machine.system_id
         )
 
+    def test__enter_rescue_mode_with_wait_failed(self):
+        system_id = make_name_without_spaces("system-id")
+        hostname = make_name_without_spaces("hostname")
+        data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.ENTERING_RESCUE_MODE,
+        }
+        failed_enter_rescue_mode_data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.FAILED_ENTERING_RESCUE_MODE,
+        }
+        machine = make_origin().Machine(data)
+        machine._handler.rescue_mode.return_value = data
+        machine._handler.read.return_value = failed_enter_rescue_mode_data
+        self.assertRaises(
+            machines.RescueModeFailure,
+            machine.enter_rescue_mode, wait=0.1
+        )
+
     def test__exit_rescue_mode(self):
         exit_machine = {
             "system_id": make_name_without_spaces("system-id"),
@@ -189,6 +228,27 @@ class TestMachine(TestCase):
         self.assertThat(result.status, Equals(deployed_machine.status))
         machine._handler.exit_rescue_mode.assert_called_once_with(
             system_id=machine.system_id
+        )
+
+    def test__exit_rescue_mode_with_wait_failed(self):
+        system_id = make_name_without_spaces("system-id")
+        hostname = make_name_without_spaces("hostname")
+        data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.EXITING_RESCUE_MODE,
+        }
+        failed_exit_rescue_mode_data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.FAILED_EXITING_RESCUE_MODE,
+        }
+        machine = make_origin().Machine(data)
+        machine._handler.exit_rescue_mode.return_value = data
+        machine._handler.read.return_value = failed_exit_rescue_mode_data
+        self.assertRaises(
+            machines.RescueModeFailure,
+            machine.exit_rescue_mode, wait=0.1
         )
 
     def test__release_with_wait(self):

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -36,6 +36,29 @@ class TestMachine(TestCase):
             "<Machine hostname=%(hostname)r system_id=%(system_id)r>"
             % machine._data))
 
+    def test__deploy_with_wait(self):
+        system_id = make_name_without_spaces("system-id")
+        hostname = make_name_without_spaces("hostname")
+        data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.DEPLOYING,
+        }
+        deployed_data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.DEPLOYED,
+        }
+        machine = make_origin().Machine(data)
+        deployed_machine = make_origin().Machine(deployed_data)
+        machine._handler.deploy.return_value = data
+        machine._handler.read.return_value = deployed_data
+        result = machine.deploy(wait=0.1)
+        self.assertThat(result.status, Equals(deployed_machine.status))
+        machine._handler.deploy.assert_called_once_with(
+            system_id=machine.system_id
+        )
+
     def test__get_power_parameters(self):
         machine = make_origin().Machine({
             "system_id": make_name_without_spaces("system-id"),

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -154,6 +154,29 @@ class TestMachine(TestCase):
             system_id=machine.system_id
         )
 
+    def test__release_with_wait(self):
+        system_id = make_name_without_spaces("system-id")
+        hostname = make_name_without_spaces("hostname")
+        data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.RELEASING,
+        }
+        allocated_data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.ALLOCATED,
+        }
+        machine = make_origin().Machine(data)
+        allocated_machine = make_origin().Machine(allocated_data)
+        machine._handler.release.return_value = data
+        machine._handler.read.return_value = allocated_data
+        result = machine.release(wait=0.1)
+        self.assertThat(result.status, Equals(allocated_machine.status))
+        machine._handler.release.assert_called_once_with(
+            system_id=machine.system_id
+        )
+
 
 class TestMachine_APIVersion(TestCase):
 

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -298,6 +298,29 @@ class TestMachine(TestCase):
             wait_interval=0.1
         )
 
+    def test__release_with_wait_failed_disk_erasing(self):
+        system_id = make_name_without_spaces("system-id")
+        hostname = make_name_without_spaces("hostname")
+        data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.RELEASING,
+        }
+        failed_disk_erase_data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.FAILED_DISK_ERASING,
+        }
+        machine = make_origin().Machine(data)
+        machine._handler.release.return_value = data
+        machine._handler.read.return_value = failed_disk_erase_data
+        self.assertRaises(
+            machines.FailedDiskErasing,
+            machine.release,
+            wait=True,
+            wait_interval=0.1
+        )
+
 
 class TestMachine_APIVersion(TestCase):
 

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -52,6 +52,12 @@ class TestMachine(TestCase):
             system_id=machine.system_id
         )
 
+    def test__enter_rescue_mode(self):
+        assert False
+
+    def test__exit_rescue_mode(self):
+        assert False
+
 
 class TestMachine_APIVersion(TestCase):
 

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -58,7 +58,7 @@ class TestMachine(TestCase):
         deployed_machine = make_origin().Machine(deployed_data)
         machine._handler.deploy.return_value = data
         machine._handler.read.return_value = deployed_data
-        result = machine.deploy(wait=0.1)
+        result = machine.deploy(wait=True, wait_interval=0.1)
         self.assertThat(result.status, Equals(deployed_machine.status))
         machine._handler.deploy.assert_called_once_with(
             system_id=machine.system_id
@@ -80,7 +80,8 @@ class TestMachine(TestCase):
         machine = make_origin().Machine(data)
         machine._handler.deploy.return_value = data
         machine._handler.read.return_value = failed_deploy_data
-        self.assertRaises(machines.FailedDeployment, machine.deploy, wait=0.1)
+        self.assertRaises(machines.FailedDeployment, machine.deploy,
+                          wait=True, wait_interval=0.1)
 
     def test__get_power_parameters(self):
         machine = make_origin().Machine({
@@ -148,7 +149,7 @@ class TestMachine(TestCase):
         erm_machine = make_origin().Machine(erm_data)
         rm_machine._handler.rescue_mode.return_value = rm_data
         rm_machine._handler.read.return_value = erm_data
-        result = rm_machine.enter_rescue_mode(wait=0.1)
+        result = rm_machine.enter_rescue_mode(wait=True, wait_interval=0.1)
         self.assertThat(result.status, Equals(erm_machine.status))
         rm_machine._handler.rescue_mode.assert_called_once_with(
             system_id=rm_machine.system_id
@@ -172,7 +173,7 @@ class TestMachine(TestCase):
         machine._handler.read.return_value = failed_enter_rescue_mode_data
         self.assertRaises(
             machines.RescueModeFailure,
-            machine.enter_rescue_mode, wait=0.1
+            machine.enter_rescue_mode, wait=True, wait_interval=0.1
         )
 
     def test__exit_rescue_mode(self):
@@ -224,7 +225,7 @@ class TestMachine(TestCase):
         deployed_machine = make_origin().Machine(deployed_data)
         machine._handler.exit_rescue_mode.return_value = data
         machine._handler.read.return_value = deployed_data
-        result = machine.exit_rescue_mode(wait=0.1)
+        result = machine.exit_rescue_mode(wait=True, wait_interval=0.1)
         self.assertThat(result.status, Equals(deployed_machine.status))
         machine._handler.exit_rescue_mode.assert_called_once_with(
             system_id=machine.system_id
@@ -248,7 +249,7 @@ class TestMachine(TestCase):
         machine._handler.read.return_value = failed_exit_rescue_mode_data
         self.assertRaises(
             machines.RescueModeFailure,
-            machine.exit_rescue_mode, wait=0.1
+            machine.exit_rescue_mode, wait=True, wait_interval=0.1
         )
 
     def test__release_with_wait(self):
@@ -268,7 +269,7 @@ class TestMachine(TestCase):
         allocated_machine = make_origin().Machine(allocated_data)
         machine._handler.release.return_value = data
         machine._handler.read.return_value = allocated_data
-        result = machine.release(wait=0.1)
+        result = machine.release(wait=True, wait_interval=0.1)
         self.assertThat(result.status, Equals(allocated_machine.status))
         machine._handler.release.assert_called_once_with(
             system_id=machine.system_id
@@ -290,7 +291,12 @@ class TestMachine(TestCase):
         machine = make_origin().Machine(data)
         machine._handler.release.return_value = data
         machine._handler.read.return_value = failed_release_data
-        self.assertRaises(machines.FailedReleasing, machine.release, wait=0.1)
+        self.assertRaises(
+            machines.FailedReleasing,
+            machine.release,
+            wait=True,
+            wait_interval=0.1
+        )
 
 
 class TestMachine_APIVersion(TestCase):


### PR DESCRIPTION
This branch adds methods to send the machine to rescue mode (and exit from rescue mode). The new methods introduce a new pattern where the caller of the function can specify the 'wait' parameter with a value for which the polling interval should be. That will return its result when the machine exits out of the transitional state and provide the machine representation for the machine in its final state.