### PR TITLE
Add the ability to save objects when any fields have changed.

### DIFF
--- a/maas/client/viscera/controllers.py
+++ b/maas/client/viscera/controllers.py
@@ -14,10 +14,10 @@ from . import (
     check_optional,
     Object,
     ObjectField,
+    ObjectFieldRelated,
     ObjectFieldRelatedSet,
     ObjectSet,
     ObjectType,
-    zones,
 )
 
 
@@ -79,8 +79,7 @@ class RackController(Object, metaclass=RackControllerType):
     system_id = ObjectField.Checked(
         "system_id", check(str), readonly=True, pk=True)
 
-    zone = zones.ZoneField(
-        "zone", readonly=True)
+    zone = ObjectFieldRelated("zone", "Zone")
 
     def __repr__(self):
         return super(RackController, self).__repr__(
@@ -144,8 +143,7 @@ class RegionController(Object, metaclass=RegionControllerType):
     system_id = ObjectField.Checked(
         "system_id", check(str), readonly=True, pk=True)
 
-    zone = zones.ZoneField(
-        "zone", readonly=True)
+    zone = ObjectFieldRelated("zone", "Zone")
 
     def __repr__(self):
         return super(RegionController, self).__repr__(

--- a/maas/client/viscera/devices.py
+++ b/maas/client/viscera/devices.py
@@ -11,10 +11,10 @@ from . import (
     check,
     Object,
     ObjectField,
+    ObjectFieldRelated,
     ObjectFieldRelatedSet,
     ObjectSet,
     ObjectType,
-    zones,
 )
 
 
@@ -53,8 +53,7 @@ class Device(Object, metaclass=DeviceType):
         "system_id", check(str), readonly=True, pk=True)
     tags = ObjectField.Checked(  # List[str]
         "tag_names", check(Sequence), readonly=True)
-    zone = zones.ZoneField(
-        "zone", readonly=True)
+    zone = ObjectFieldRelated("zone", "Zone")
 
     def __repr__(self):
         return super(Device, self).__repr__(

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -20,7 +20,6 @@ from . import (
     ObjectFieldRelatedSet,
     ObjectSet,
     ObjectType,
-    zones,
 )
 from ..bones import CallError
 from ..enum import NodeStatus
@@ -190,8 +189,7 @@ class Machine(Object, metaclass=MachineType):
 
     # virtualblockdevice_set
 
-    zone = zones.ZoneField(
-        "zone", readonly=True)
+    zone = ObjectFieldRelated("zone", "Zone")
 
     async def deploy(
             self, user_data: typing.Union[bytes, str]=None,

--- a/maas/client/viscera/tests/test_zones.py
+++ b/maas/client/viscera/tests/test_zones.py
@@ -12,6 +12,7 @@ from .. import zones
 
 from ..testing import bind
 from ...testing import (
+    make_name,
     make_string_without_spaces,
     TestCase,
 )
@@ -84,6 +85,13 @@ class TestZones(TestCase):
 
 
 class TestZone(TestCase):
+
+    def test__zone_unloaded(self):
+        Zone = make_origin().Zone
+        name = make_name("zone")
+        zone = Zone(name)
+        self.assertFalse(zone.loaded)
+        self.assertEqual(name, zone.name)
 
     def test__zone_read(self):
         Zone = make_origin().Zone

--- a/maas/client/viscera/zones.py
+++ b/maas/client/viscera/zones.py
@@ -2,7 +2,6 @@
 
 __all__ = [
     "Zone",
-    "ZoneField",
     "Zones",
 ]
 
@@ -31,7 +30,7 @@ class ZonesType(ObjectType):
         :param description: A description of the `Zone`.
         :type description: `str`
         :returns: The create `Zone`
-        :rtype: `Fabric`
+        :rtype: `Zone`
         """
         params = {'name': name}
         if description is not None:
@@ -57,7 +56,7 @@ class Zone(Object, metaclass=ZoneType):
         "id", check(int), readonly=True)
 
     name = ObjectField.Checked(
-        "name", check(str), check(str))
+        "name", check(str), check(str), pk=True)
     description = ObjectField.Checked(
         "description", check(str), check(str))
 
@@ -67,13 +66,6 @@ class Zone(Object, metaclass=ZoneType):
 
     async def delete(self):
         """
-        Deletes the `Fabric` from MAAS.
+        Deletes the `Zone` from MAAS.
         """
         return await self._handler.delete(name=self.name)
-
-
-class ZoneField(ObjectField):
-    """An object field for a `Zone`."""
-
-    def datum_to_value(self, instance, datum):
-        return instance._origin.Zone(datum)


### PR DESCRIPTION
The `Object` class not tracks changed fields on the object. If the handler for the object supports `update` then the `save` method on the object will send the changed fields using the `update` on the handler. The updated object response from `update` will then replace the `_data` for the object.

This adds two new fields on the `Object` `_orig_data` and `_changed_data`. `_orig_data` holds the original data when the object was created, refreshed, or saved. `_changed_data` tracks the fields and the updated value for the `Object`. If a field is changed from updated back to its original value then its removed from `_changed_data`.