### PR TITLE
Add vlan facade

### DIFF
--- a/maas/client/facade.py
+++ b/maas/client/facade.py
@@ -230,6 +230,14 @@ class Client:
         }
 
     @facade
+    def vlans(origin):
+        return {
+            "create": origin.Vlans.create,
+            "get": origin.Vlan.read,
+            "list": origin.Vlans.read,
+        }
+
+    @facade
     def zones(origin):
         return {
             "create": origin.Zones.create,

--- a/maas/client/tests/test_facade.py
+++ b/maas/client/tests/test_facade.py
@@ -190,6 +190,15 @@ class TestClient(TestCase):
             ),
         ))
 
+    def test__client_maps_vlans(self):
+        self.assertThat(self.client, MatchesClient(
+            vlans=MatchesFacade(
+                create=self.origin.Vlans.create,
+                get=self.origin.Vlan.read,
+                list=self.origin.Vlans.read,
+            ),
+        ))
+
     def test__client_maps_zones(self):
         self.assertThat(self.client, MatchesClient(
             zones=MatchesFacade(

--- a/maas/client/viscera/vlans.py
+++ b/maas/client/viscera/vlans.py
@@ -49,12 +49,12 @@ class Vlan(Object, metaclass=VlanType):
     """A VLAN in a fabric."""
 
     id = ObjectField.Checked(
-        "id", check(int), readonly=True)
+        "id", check(int), readonly=True, pk=0)
 
     fabric = ObjectFieldRelated(
-        "fabric_id", "Fabric", readonly=True, pk=0)
+        "fabric_id", "Fabric", readonly=True)
     vid = ObjectField.Checked(
-        "vid", check(int), check(int), pk=1)
+        "vid", check(int), check(int))
 
     name = ObjectField.Checked(
         "name", check_optional(str), check_optional(str))


### PR DESCRIPTION
And fix primary_keys for vlans, so that when passing it as a object for creation of another it gets converted to the correct primary_keys.

Fixes https://github.com/maas/python-libmaas/issues/117