### PR TITLE
Add documentation for networking objects. Cleanup create for ip_ranges. Rename ipranges to ip_ranges on the facade.

### DIFF
--- a/doc.yaml
+++ b/doc.yaml
@@ -13,6 +13,7 @@ pages:
   - Client:
     - Introduction: client/index.md
     - Nodes: client/nodes.md
+    - Networking: client/networking.md
     - Events: client/events.md
     - Others: client/other.md
   - Internals:

--- a/doc/client/networking.md
+++ b/doc/client/networking.md
@@ -1,0 +1,130 @@
+<h1>Fabrics, VLANs, Subnets, Spaces, IP Ranges, Static Routes</h1>
+
+Given a ``Client`` instance bound to your MAAS server, you can
+interrogate your entire networking configuration.
+
+## Read networking
+
+``fabrics``, ``subnets``, ``spaces``, ``ip_ranges``, and ``static_routes`` is
+exposed directly on your ``Client`` instance. ``vlans`` are nested under each
+``Fabric``.
+
+```pycon
+>>> fabrics = client.fabrics.list()
+>>> len(fabrics)
+1
+>>> default_fabric = fabrics.get_default()
+>>> default_fabric.name
+'fabric-0'
+>>> default_fabric.vlans
+<Vlans.Managed#Fabric length=1 items=[<Vlan name='untagged' vid=0>]>
+>>> for vlan in default_fabric.vlans:
+...     print(vlan)
+...
+<Vlan name='untagged' vid=0>
+>>>
+```
+
+Get a specific subnet and view the ``Vlan`` and ``Fabric`` that it is
+assigned to. Going up the tree from ``Vlan`` to ``Fabric`` results in an
+unloaded ``Fabric``. Calling ``refresh`` on ``Fabric`` will load the object
+from MAAS.
+
+
+```pycon
+>>> vm_subnet = client.subnets.get('192.168.122.0/24')
+>>> vm_subnet.cidr
+'192.168.122.0/24'
+>>> vm_subnet.vlan
+<Vlan name='untagged' vid=0>
+>>> fabric = vm_subnet.vlan.fabric
+>>> fabric
+<Fabric id=20 (unloaded)>
+>>> fabric.refresh()
+>>> fabric.vlans
+Traceback (most recent call last):
+...
+ObjectNotLoaded: cannot access attribute 'vlans' of object 'Fabric'
+>>> fabric.is_loaded
+False
+>>> fabric.refresh()
+>>> fabric.is_loaded
+True
+>>> fabric.vlans
+<Vlans.Managed#Fabric length=1 items=[<Vlan name='untagged' vid=0>]>
+```
+
+Access to ``spaces``, ``ip_ranges``, and ``static_routes`` works similarly.
+
+```pycon
+>>> client.spaces.list()
+>>> client.ip_ranges.list()
+>>> client.static_routes.list()
+```
+
+## Create fabric & vlan
+
+Creating a new fabric and vlan is done directly from each set of objects on
+the ``Client`` respectively.
+
+```pycon
+>>> new_fabric = client.fabrics.create()
+>>> new_fabric.name
+'fabric-2'
+>>> new_vlan = new_fabric.vlans.create(20)
+>>> new_vlan
+<Vlan name='' vid=20>
+>>> new_vlan.fabric
+<Fabric id=2 (unloaded)>
+```
+
+## Create subnet
+
+Create a new subnet and assign it to an existing vlan.
+
+```pycon
+>>> new_subnet = client.subnets.create('192.168.128.0/24', new_vlan)
+>>> new_subnet.cidr
+'192.168.128.0/24'
+>>> new_subnet.vlan
+<Vlan name='' vid=20>
+```
+
+## Update subnet
+
+Quickly move the newly created subnet from vlan to default fabric
+untagged vlan.
+
+```pycon
+>>> default_fabric = client.fabrics.get_default()
+>>> untagged = default_fabric.vlans.get_default()
+>>> new_subnet.vlan = untagged
+>>> new_subnet.save()
+>>> new_subnet.vlan
+<Vlan name='untagged' vid=0>
+```
+
+## Delete subnet
+
+``delete`` exists directly on the ``Subnet`` object so deletion is simple.
+
+```pycon
+>>> new_subnet.delete()
+>>>
+```
+
+## Enable DHCP
+
+Create a new dynamic IP range and turn DHCP on the selected
+rack controller.
+
+```pycon
+>>> fabric = client.fabrics.get_default()
+>>> untagged = fabric.vlans.get_default()
+>>> new_range = client.ip_ranges.create(
+...     '192.168.122.100', '192.168.122.200', type=IPRangeType.DYNAMIC)
+>>> rack = client.rack_controllers.list()[0]
+>>> untagged.dhcp_on = True
+>>> untagged.primary_rack = rack
+>>> untagged.save()
+```

--- a/maas/client/enum.py
+++ b/maas/client/enum.py
@@ -66,3 +66,10 @@ class RDNSMode(enum.IntEnum):
     ENABLED = 1
     #: Generate RFC2317 glue if needed (Subnet is too small for its own zone.)
     RFC2317 = 2
+
+
+class IPRangeType(enum.Enum):
+    # Dynamic IP Range.
+    DYNAMIC = 'dynamic'
+    # Reserved for exclusive use by MAAS or user.
+    RESERVED = 'reserved'

--- a/maas/client/facade.py
+++ b/maas/client/facade.py
@@ -155,7 +155,7 @@ class Client:
         }
 
     @facade
-    def ipranges(origin):
+    def ip_ranges(origin):
         return {
             "create": origin.IPRanges.create,
             "get": origin.IPRange.read,

--- a/maas/client/tests/test_facade.py
+++ b/maas/client/tests/test_facade.py
@@ -107,9 +107,9 @@ class TestClient(TestCase):
             )
         ))
 
-    def test__client_maps_ipranges(self):
+    def test__client_maps_ip_ranges(self):
         self.assertThat(self.client, MatchesClient(
-            ipranges=MatchesFacade(
+            ip_ranges=MatchesFacade(
                 create=self.origin.IPRanges.create,
                 get=self.origin.IPRange.read,
                 list=self.origin.IPRanges.read,

--- a/maas/client/viscera/ipranges.py
+++ b/maas/client/viscera/ipranges.py
@@ -12,8 +12,10 @@ from . import (
     ObjectFieldRelated,
     ObjectSet,
     ObjectType,
+    to,
 )
 from .subnets import Subnet
+from ..enum import IPRangeType
 from typing import Union
 
 TYPE = type
@@ -26,18 +28,25 @@ class IPRangesType(ObjectType):
         data = await cls._handler.read()
         return cls(map(cls._object, data))
 
-    async def create(cls, *, start_ip: str, end_ip: str, type: str,
-                     comment: str=None, subnet: Union[int, Subnet]=None):
+    async def create(
+            cls, start_ip: str, end_ip: str, *,
+            type: IPRangeType=IPRangeType.RESERVED,
+            comment: str=None, subnet: Union[Subnet, int]=None):
         """
         Create a `IPRange` in MAAS.
 
-        :param name: The name of the `IPRange` (optional, will be given a
-        default value if not specified).
-        :type name: `str`
-        :param description: A description of the `IPRange` (optional).
-        :type description: `str`
-        :param class_type: The class type of the `IPRange` (optional).
-        :type class_type: `str`
+        :param start_ip: First IP address in the range (required).
+        :type start_ip: `str`
+        :parma end_ip: Last IP address in the range (required).
+        :type end_ip: `str`
+        :param type: Type of IP address range (optional).
+        :type type: `IPRangeType`
+        :param comment: Reason for the IP address range (optional).
+        :type comment: `str`
+        :param subnet: Subnet the IP address range should be created on
+            (optional). By default MAAS will calculate the correct subnet
+            based on the `start_ip` and `end_ip`.
+        :type subnet: `Subnet` or `int`
         :returns: The created IPRange
         :rtype: `IPRange`
         """
@@ -83,7 +92,7 @@ class IPRange(Object, metaclass=IPRangeType):
     end_ip = ObjectField.Checked(
         "end_ip", check(str))
     type = ObjectField.Checked(
-        "type", check(str), readonly=True)
+        "type", to(IPRangeType), readonly=True)
     comment = ObjectField.Checked(
         "comment", check(str))
     subnet = ObjectFieldRelated("subnet", "Subnet", readonly=True, pk=0)

--- a/maas/client/viscera/subnets.py
+++ b/maas/client/viscera/subnets.py
@@ -125,6 +125,10 @@ class Subnet(Object, metaclass=SubnetType):
     rdns_mode = ObjectField.Checked("rdns_mode", to(RDNSMode))
     dns_servers = ObjectField.Checked("dns_servers", check(list))
 
+    def __repr__(self):
+        return super(Subnet, self).__repr__(
+            fields={"cidr", "name", "vlan"})
+
     async def delete(self):
         """Delete this Subnet."""
         await self._handler.delete(id=self.id)


### PR DESCRIPTION
I did not add the documentation for configuring a relay_vlan, at the moment it does not work. I will fix that up and add documentation in a later branch.