### PR TITLE
fix: subnet names are not readonly

### DIFF
--- a/maas/client/viscera/subnets.py
+++ b/maas/client/viscera/subnets.py
@@ -108,7 +108,7 @@ class Subnet(Object, metaclass=SubnetType):
     cidr = ObjectField.Checked(
         "cidr", check(str), readonly=True)
     name = ObjectField.Checked(
-        "name", check(str), readonly=True)
+        "name", check(str))
 
     # description is allowed in the create call and displayed in the UI
     # but never returned by the API


### PR DESCRIPTION
Allow modifying the subnet name, as allowed by: https://github.com/maas/python-libmaas/blob/master/maas/client/bones/testing/api22.json#L2996

Tested verified working.
