### PR TITLE
Add ability to reset machine configuration. Add ability to update owner_data on a machine.

### DIFF
--- a/doc/client/nodes.md
+++ b/doc/client/nodes.md
@@ -234,6 +234,24 @@ NodeStatus.BROKEN
 NodeStatus.READY
 ```
 
+## Owner Data
+
+Owner data is extra information that you can set on a machine to hold some state information.
+
+**Note:** Once the machine is no longer in your control the information will be lost.
+
+```pycon
+>>> machine.owner_data
+{}
+>>> machine.owner_data['state'] = 'my-state-info'
+>>> machine.save()
+>>> machine.owner_data
+{'state': 'my-state-info'}
+>>> machine.release()
+>>> machine.owner_data
+{}
+```
+
 ## Power Control
 
 The power state of a machine can be controlled outside of deploy, releasing, and rescue mode. If you need to control the power of a BMC independently the `power_on`, `power_off` and `query_power_state` can be of help.
@@ -250,4 +268,16 @@ PowerState.OFF
 PowerState.ON
 >>> machine.query_power_state()
 PowerState.ON
+```
+
+## Reset Configuration
+
+It is possible to restore the machine back to exactly how it was after you completed commissioning. This is helpful when you have made a configuration that you no longer want or you want to start fresh.
+
+```pycon
+>>> machine.restore_default_configuration()
+>>> # Only restore networking.
+>>> machine.restore_networking_configuration()
+>>> # Only restore storage configuration.
+>>> machine.restore_storage_configuration()
 ```

--- a/maas/client/viscera/tests/test.py
+++ b/maas/client/viscera/tests/test.py
@@ -848,15 +848,17 @@ class TestObjectField(TestCase):
         class Example(Object):
             alice = AliceField("alice")
 
+        alice = make_name_without_spaces("alice")
+        new_alice = make_name_without_spaces("alice")
         example = Example({
-            'alice': sentinel.alice
+            'alice': alice
         })
 
-        example.alice = sentinel.new_alice
+        example.alice = new_alice
         self.assertThat(example._changed_data, Equals({
-            'alice': sentinel.new_alice
+            'alice': new_alice
         }))
-        example.alice = sentinel.alice
+        example.alice = alice
         self.assertThat(example._changed_data, Equals({}))
 
     def test__delete_marks_field_deleted(self):
@@ -884,16 +886,18 @@ class TestObjectField(TestCase):
         class Example(Object):
             alice = AliceField("alice")
 
+        alice = make_name_without_spaces('alice')
+        new_alice = make_name_without_spaces('alice')
         example = Example({
-            'alice': sentinel.alice
+            'alice': alice
         })
 
         del example.alice
-        example.alice = sentinel.new_alice
+        example.alice = new_alice
         self.assertThat(example._changed_data, Equals({
-            'alice': sentinel.new_alice
+            'alice': new_alice
         }))
-        example.alice = sentinel.alice
+        example.alice = alice
         self.assertThat(example._changed_data, Equals({}))
 
 


### PR DESCRIPTION
This also fixes an issue where when `_data` was reset `_orig_data` and `_changed_data` where not set correctly.