### PR TITLE
Improved Interfaces and Node objects

### DIFF
--- a/maas/client/enum.py
+++ b/maas/client/enum.py
@@ -59,6 +59,19 @@ class NodeStatus(enum.IntEnum):
     FAILED_TESTING = 22
 
 
+class NodeType(enum.IntEnum):
+    #: Machine
+    MACHINE = 0
+    #: Device
+    DEVICE = 1
+    #: Rack
+    RACK_CONTROLLER = 2
+    #: Region
+    REGION_CONTROLLER = 3
+    #: Region+Rack
+    REGION_AND_RACK_CONTROLLER = 4
+
+
 class PowerState(enum.Enum):
     #: On
     ON = 'on'

--- a/maas/client/viscera/__init__.py
+++ b/maas/client/viscera/__init__.py
@@ -435,8 +435,7 @@ class Object(ObjectBasics, metaclass=ObjectType):
                     found = False
                     for alt_name, _ in alt_descriptors[0]:
                         if hasattr(self, alt_name):
-                            obj = await cls.read(
-                                getattr(self, descriptors[0][0]))
+                            obj = await cls.read(getattr(self, alt_name))
                             found = True
                             break
                     if not found:

--- a/maas/client/viscera/__init__.py
+++ b/maas/client/viscera/__init__.py
@@ -255,13 +255,13 @@ class Object(ObjectBasics, metaclass=ObjectType):
             descriptors, alt_descriptors = get_pk_descriptors(type(self))
             if len(descriptors) == 1:
                 if isinstance(data, Mapping):
-                    obj_data = {}
+                    self._data = {}
                     try:
-                        obj_data[descriptors[0][1].name] = (
+                        self._data[descriptors[0][1].name] = (
                             data[descriptors[0][1].name])
                     except KeyError:
                         found_name = set_alt_pk_value(
-                            alt_descriptors[0], obj_data, data)
+                            alt_descriptors[0], self._data, data)
                         if found_name:
                             # Validate that the set data is correct and
                             # can be converted to the python value.
@@ -272,6 +272,9 @@ class Object(ObjectBasics, metaclass=ObjectType):
                         # Validate that the set data is correct and
                         # can be converted to the python value.
                         getattr(self, descriptors[0][0])
+                    # Reset self._data so _orig_data and _changed_data is
+                    # correct.
+                    self._data = self._data
                 else:
                     self._data = {
                         descriptors[0][1].name: data
@@ -314,9 +317,14 @@ class Object(ObjectBasics, metaclass=ObjectType):
                         "data must be a mapping or a sequence, not %s" % (
                             type(data).__name__))
             else:
-                raise TypeError(
-                    "data must be a mapping, not %s"
-                    % type(data).__name__)
+                if not isinstance(data, Mapping):
+                    raise TypeError(
+                        "data must be a mapping, not %s"
+                        % type(data).__name__)
+                else:
+                    raise ValueError(
+                        "data cannot be incomplete without any primary keys "
+                        "defined")
         self._orig_data = deepcopy(self._data)
         if local_data is not None:
             if isinstance(local_data, Mapping):

--- a/maas/client/viscera/__init__.py
+++ b/maas/client/viscera/__init__.py
@@ -206,7 +206,7 @@ def get_pk_descriptors(cls):
             elif type(descriptor.alt_pk) is int:
                 alt_pk_fields[descriptor.alt_pk].append((name, descriptor))
     if len(pk_fields) == 1:
-        return ((pk_fields.popitem(),),(alt_pk_fields[0],))
+        return ((pk_fields.popitem(),), (alt_pk_fields[0],))
     elif len(pk_fields) > 1:
         unique_pk_fields = {
             name: descriptor

--- a/maas/client/viscera/controllers.py
+++ b/maas/client/viscera/controllers.py
@@ -7,8 +7,6 @@ __all__ = [
     "RegionControllers",
 ]
 
-from collections import Sequence
-
 from . import (
     check,
     check_optional,

--- a/maas/client/viscera/controllers.py
+++ b/maas/client/viscera/controllers.py
@@ -12,35 +12,31 @@ from collections import Sequence
 from . import (
     check,
     check_optional,
-    Object,
     ObjectField,
-    ObjectFieldRelated,
-    ObjectFieldRelatedSet,
-    ObjectSet,
-    ObjectType,
+    to,
 )
+from .nodes import (
+    Node,
+    Nodes,
+    NodesType,
+    NodeTypeMeta,
+)
+from ..enum import PowerState
 
 
-class RackControllersType(ObjectType):
+class RackControllersType(NodesType):
     """Metaclass for `RackControllers`."""
 
-    async def read(cls):
-        data = await cls._handler.read()
-        return cls(map(cls._object, data))
 
-
-class RackControllers(ObjectSet, metaclass=RackControllersType):
+class RackControllers(Nodes, metaclass=RackControllersType):
     """The set of rack-controllers stored in MAAS."""
 
 
-class RackControllerType(ObjectType):
-
-    async def read(cls, system_id):
-        data = await cls._handler.read(system_id=system_id)
-        return cls(data)
+class RackControllerType(NodeTypeMeta):
+    """Metaclass for `RackController`."""
 
 
-class RackController(Object, metaclass=RackControllerType):
+class RackController(Node, metaclass=RackControllerType):
     """A rack-controller stored in MAAS."""
 
     architecture = ObjectField.Checked(
@@ -49,63 +45,31 @@ class RackController(Object, metaclass=RackControllerType):
         "cpu_count", check(int), check(int))
     distro_series = ObjectField.Checked(
         "distro_series", check(str), check(str))
-
-    # domain
-
-    fqdn = ObjectField.Checked(
-        "fqdn", check(str), check(str))
-    hostname = ObjectField.Checked(
-        "hostname", check(str), check(str))
-
-    interfaces = ObjectFieldRelatedSet("interface_set", "Interfaces")
-    ip_addresses = ObjectField.Checked(  # List[str]
-        "ip_addresses", check(Sequence), readonly=True)
     memory = ObjectField.Checked(
         "memory", check(int), check(int))
-
-    # node_type
-    # node_type_name
-    # osystem
-
-    # TODO: Use an enum here.
+    osystem = ObjectField.Checked(
+        "osystem", check(str), readonly=True)
     power_state = ObjectField.Checked(
-        "power_state", check(str), readonly=True)
+        "power_state", to(PowerState), readonly=True)
 
     # power_type
     # service_set
-    # status_action
     # swap_size
 
-    system_id = ObjectField.Checked(
-        "system_id", check(str), readonly=True, pk=True)
 
-    zone = ObjectFieldRelated("zone", "Zone")
-
-    def __repr__(self):
-        return super(RackController, self).__repr__(
-            fields={"system_id", "hostname"})
-
-
-class RegionControllersType(ObjectType):
+class RegionControllersType(NodesType):
     """Metaclass for `RegionControllers`."""
 
-    async def read(cls):
-        data = await cls._handler.read()
-        return cls(map(cls._object, data))
 
-
-class RegionControllers(ObjectSet, metaclass=RegionControllersType):
+class RegionControllers(Nodes, metaclass=RegionControllersType):
     """The set of region-controllers stored in MAAS."""
 
 
-class RegionControllerType(ObjectType):
-
-    async def read(cls, system_id):
-        data = await cls._handler.read(system_id=system_id)
-        return cls(data)
+class RegionControllerType(NodeTypeMeta):
+    """Metaclass for `RegionController`."""
 
 
-class RegionController(Object, metaclass=RegionControllerType):
+class RegionController(Node, metaclass=RegionControllerType):
     """A region-controller stored in MAAS."""
 
     architecture = ObjectField.Checked(
@@ -114,37 +78,13 @@ class RegionController(Object, metaclass=RegionControllerType):
         "cpu_count", check(int), check(int))
     distro_series = ObjectField.Checked(
         "distro_series", check(str), check(str))
-
-    # domain
-
-    fqdn = ObjectField.Checked(
-        "fqdn", check(str), check(str))
-    hostname = ObjectField.Checked(
-        "hostname", check(str), check(str))
-    interfaces = ObjectFieldRelatedSet("interface_set", "Interfaces")
-    ip_addresses = ObjectField.Checked(  # List[str]
-        "ip_addresses", check(Sequence), readonly=True)
     memory = ObjectField.Checked(
         "memory", check(int), check(int))
-
-    # node_type
-    # node_type_name
-    # osystem
-
-    # TODO: Use an enum here.
+    osystem = ObjectField.Checked(
+        "osystem", check(str), readonly=True)
     power_state = ObjectField.Checked(
-        "power_state", check(str), readonly=True)
+        "power_state", to(PowerState), readonly=True)
 
     # power_type
     # service_set
-    # status_action
     # swap_size
-
-    system_id = ObjectField.Checked(
-        "system_id", check(str), readonly=True, pk=True)
-
-    zone = ObjectFieldRelated("zone", "Zone")
-
-    def __repr__(self):
-        return super(RegionController, self).__repr__(
-            fields={"system_id", "hostname"})

--- a/maas/client/viscera/devices.py
+++ b/maas/client/viscera/devices.py
@@ -7,54 +7,25 @@ __all__ = [
 
 from collections import Sequence
 
-from . import (
-    check,
-    Object,
-    ObjectField,
-    ObjectFieldRelated,
-    ObjectFieldRelatedSet,
-    ObjectSet,
-    ObjectType,
+from .nodes import (
+    Node,
+    Nodes,
+    NodesType,
+    NodeTypeMeta,
 )
 
 
-class DevicesType(ObjectType):
+class DevicesType(NodesType):
     """Metaclass for `Devices`."""
 
-    async def read(cls):
-        data = await cls._handler.read()
-        return cls(map(cls._object, data))
 
-
-class Devices(ObjectSet, metaclass=DevicesType):
+class Devices(Nodes, metaclass=DevicesType):
     """The set of devices stored in MAAS."""
 
 
-class DeviceType(ObjectType):
-
-    async def read(cls, system_id):
-        data = await cls._handler.read(system_id=system_id)
-        return cls(data)
+class DeviceType(NodeTypeMeta):
+    """Metaclass for `Device`."""
 
 
-class Device(Object, metaclass=DeviceType):
+class Device(Node, metaclass=DeviceType):
     """A device stored in MAAS."""
-
-    hostname = ObjectField.Checked(
-        "hostname", check(str), check(str))
-    interfaces = ObjectFieldRelatedSet("interface_set", "Interfaces")
-    ip_addresses = ObjectField.Checked(  # List[str]
-        "ip_addresses", check(Sequence), readonly=True)
-
-    # owner
-    # resource_uri
-
-    system_id = ObjectField.Checked(
-        "system_id", check(str), readonly=True, pk=True)
-    tags = ObjectField.Checked(  # List[str]
-        "tag_names", check(Sequence), readonly=True)
-    zone = ObjectFieldRelated("zone", "Zone")
-
-    def __repr__(self):
-        return super(Device, self).__repr__(
-            fields={"system_id", "hostname"})

--- a/maas/client/viscera/devices.py
+++ b/maas/client/viscera/devices.py
@@ -5,8 +5,6 @@ __all__ = [
     "Devices",
 ]
 
-from collections import Sequence
-
 from .nodes import (
     Node,
     Nodes,

--- a/maas/client/viscera/interfaces.py
+++ b/maas/client/viscera/interfaces.py
@@ -102,14 +102,13 @@ class Interface(Object, metaclass=InterfaceType):
         "tags", check(list), check(list))
     params = ObjectField.Checked(
         "params", check(dict), check(dict))
-
-    vlan = ObjectFieldRelated("vlan", "Vlan", reverse=None)
     parents = ObjectFieldRelatedSet(
         "parents", "Interfaces", reverse=None,
         map_func=map_nic_name_to_dict)
     children = ObjectFieldRelatedSet(
         "children", "Interfaces", reverse=None,
         map_func=map_nic_name_to_dict)
+    vlan = ObjectFieldRelated("vlan", "Vlan", reverse=None)
 
     # links
     # discovered

--- a/maas/client/viscera/interfaces.py
+++ b/maas/client/viscera/interfaces.py
@@ -10,6 +10,7 @@ from . import (
     Object,
     ObjectField,
     ObjectFieldRelated,
+    ObjectFieldRelatedSet,
     ObjectSet,
     ObjectType,
 )
@@ -64,31 +65,54 @@ class InterfaceType(ObjectType):
         return cls(data, {"node_system_id": system_id})
 
 
+def map_nic_name_to_dict(instance, value):
+    """Convert a name of interface into a dictionary.
+
+    `parents` and `children` just hold a list of interface names. This is need
+    so instead they can return a `ObjectSet`.
+
+    '__incomplete__' is set so the object knows that the data passed is
+    incomplete data.
+    """
+    return {
+        'system_id': instance._data['system_id'],
+        'name': value,
+        '__incomplete__': True
+    }
+
+
 class Interface(Object, metaclass=InterfaceType):
     """A interface on a machine."""
 
+    node = ObjectFieldRelated(
+        "system_id", "Node", readonly=True, pk=0)
     id = ObjectField.Checked(
-        "id", check(int), readonly=True)
+        "id", check(int), readonly=True, pk=1)
     type = ObjectField.Checked(
         "type", check(str), readonly=True)
     name = ObjectField.Checked(
-        "name", check(str), check(str))
+        "name", check(str), check(str), alt_pk=1)
     mac_address = ObjectField.Checked(
         "mac_address", check(str), check(str))
     enabled = ObjectField.Checked(
         "enabled", check(bool), check(bool))
     effective_mtu = ObjectField.Checked(
         "effective_mtu", check(int), readonly=True)
+    tags = ObjectField.Checked(
+        "tags", check(list), check(list))
+    params = ObjectField.Checked(
+        "params", check(dict), check(dict))
 
     vlan = ObjectFieldRelated("vlan", "Vlan", reverse=None)
+    parents = ObjectFieldRelatedSet(
+        "parents", "Interfaces", reverse=None,
+        map_func=map_nic_name_to_dict)
+    children = ObjectFieldRelatedSet(
+        "children", "Interfaces", reverse=None,
+        map_func=map_nic_name_to_dict)
 
-    # parents
     # links
-    # vlan
     # discovered
-    # tags
-    # children
-    # params
 
     def __repr__(self):
         return super(Interface, self).__repr__(

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -15,12 +15,8 @@ import typing
 from . import (
     check,
     check_optional,
-    Object,
     ObjectField,
     ObjectFieldRelated,
-    ObjectFieldRelatedSet,
-    ObjectSet,
-    ObjectType,
     to,
 )
 from ..bones import CallError
@@ -33,6 +29,12 @@ from ..errors import (
     MAASException,
     OperationNotAllowed,
     PowerError
+)
+from .nodes import (
+    Node,
+    Nodes,
+    NodesType,
+    NodeTypeMeta,
 )
 
 
@@ -67,12 +69,8 @@ def calculate_params_diff(old_params: dict, new_params: dict):
     return params_diff
 
 
-class MachinesType(ObjectType):
+class MachinesType(NodesType):
     """Metaclass for `Machines`."""
-
-    async def read(cls):
-        data = await cls._handler.read()
-        return cls(map(cls._object, data))
 
     async def create(
             cls, architecture: str, mac_addresses: typing.Sequence[str],
@@ -206,18 +204,19 @@ class FailedDiskErasing(MAASException):
     """Machine failed to erase disk when releasing."""
 
 
-class Machines(ObjectSet, metaclass=MachinesType):
+class Machines(Nodes, metaclass=MachinesType):
     """The set of machines stored in MAAS."""
 
 
-class MachineType(ObjectType):
+class MachineType(NodeTypeMeta):
+    """Metaclass for `Machine`."""
 
     async def read(cls, system_id):
         data = await cls._handler.read(system_id=system_id)
         return cls(data)
 
 
-class Machine(Object, metaclass=MachineType):
+class Machine(Node, metaclass=MachineType):
     """A machine stored in MAAS."""
 
     architecture = ObjectField.Checked(
@@ -229,29 +228,24 @@ class Machine(Object, metaclass=MachineType):
     disable_ipv4 = ObjectField.Checked(
         "disable_ipv4", check(bool), check(bool))
     distro_series = ObjectField.Checked(
-        "distro_series", check(str), check(str))
-    hostname = ObjectField.Checked(
-        "hostname", check(str), check(str))
+        "distro_series", check(str), readonly=True)
     hwe_kernel = ObjectField.Checked(
         "hwe_kernel", check_optional(str), check_optional(str))
-    ip_addresses = ObjectField.Checked(  # List[str]
-        "ip_addresses", check(Sequence), readonly=True)
     memory = ObjectField.Checked(
         "memory", check(int), check(int))
     min_hwe_kernel = ObjectField.Checked(
         "min_hwe_kernel", check_optional(str), check_optional(str))
+    osystem = ObjectField.Checked(
+        "osystem", check(str), readonly=True)
     owner_data = ObjectField.Checked(
         "owner_data", check(dict), check(dict))
 
     boot_interface = ObjectFieldRelated(
         "boot_interface", "Interface", readonly=True)
-    interfaces = ObjectFieldRelatedSet("interface_set", "Interfaces")
 
     # blockdevice_set
     # macaddress_set
     # netboot
-    # osystem
-    # owner
     # physicalblockdevice_set
 
     power_state = ObjectField.Checked(
@@ -274,15 +268,7 @@ class Machine(Object, metaclass=MachineType):
         "status_name", check(str), readonly=True)
 
     # swap_size
-
-    system_id = ObjectField.Checked(
-        "system_id", check(str), readonly=True, pk=True)
-    tags = ObjectField.Checked(  # List[str]
-        "tag_names", check(Sequence), readonly=True)
-
     # virtualblockdevice_set
-
-    zone = ObjectFieldRelated("zone", "Zone")
 
     async def save(self):
         """Save the machine in MAAS."""
@@ -689,7 +675,3 @@ class Machine(Object, metaclass=MachineType):
         """
         self._data = await self._handler.restore_storage_configuration(
             system_id=self.system_id)
-
-    def __repr__(self):
-        return super(Machine, self).__repr__(
-            fields={"system_id", "hostname"})

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -8,7 +8,6 @@ __all__ = [
 import asyncio
 import base64
 import bson
-from collections import Sequence
 from http import HTTPStatus
 import typing
 

--- a/maas/client/viscera/nodes.py
+++ b/maas/client/viscera/nodes.py
@@ -1,0 +1,117 @@
+"""Objects for nodes."""
+
+__all__ = [
+    "Node",
+    "Nodes",
+]
+
+from collections import Sequence
+
+from . import (
+    check,
+    Object,
+    ObjectField,
+    ObjectFieldRelated,
+    ObjectFieldRelatedSet,
+    ObjectSet,
+    ObjectType,
+    to,
+)
+from ..enum import NodeType
+
+
+class NodesType(ObjectType):
+    """Metaclass for `Nodes`."""
+
+    async def read(cls):
+        data = await cls._handler.read()
+        return cls(map(cls._object, data))
+
+
+class Nodes(ObjectSet, metaclass=NodesType):
+    """The set of nodes stored in MAAS."""
+
+
+class NodeTypeMeta(ObjectType):
+    """Metaclass for `Node`."""
+
+    async def read(cls, system_id):
+        data = await cls._handler.read(system_id=system_id)
+        return cls(data)
+
+
+class Node(Object, metaclass=NodeTypeMeta):
+    """A node stored in MAAS."""
+
+    # domain
+
+    fqdn = ObjectField.Checked(
+        "fqdn", check(str), readonly=True)
+    hostname = ObjectField.Checked(
+        "hostname", check(str), check(str))
+    interfaces = ObjectFieldRelatedSet("interface_set", "Interfaces")
+    ip_addresses = ObjectField.Checked(  # List[str]
+        "ip_addresses", check(Sequence), readonly=True)
+    node_type = ObjectField.Checked(
+        "node_type", to(NodeType), readonly=True)
+    owner = ObjectFieldRelated("owner", "User")
+    system_id = ObjectField.Checked(
+        "system_id", check(str), readonly=True, pk=True)
+    tags = ObjectField.Checked(  # List[str]
+        "tag_names", check(Sequence), readonly=True)
+    zone = ObjectFieldRelated("zone", "Zone")
+
+    def __repr__(self):
+        return super(Node, self).__repr__(
+            fields={"system_id", "hostname"})
+
+    def as_machine(self):
+        """Convert to a `Machine` object.
+
+        `node_type` must be `NodeType.MACHINE`.
+        """
+        from .machines import Machine
+        if self.node_type != NodeType.MACHINE:
+            raise ValueError(
+                'Cannot convert to `Machine`, node_type is not a machine.')
+        return Machine(self._data)
+
+    def as_device(self):
+        """Convert to a `Device` object.
+
+        `node_type` must be `NodeType.DEVICE`.
+        """
+        from .devices import Device
+        if self.node_type != NodeType.DEVICE:
+            raise ValueError(
+                'Cannot convert to `Device`, node_type is not a device.')
+        return Device(self._data)
+
+    def as_rack_controller(self):
+        """Convert to a `RackController` object.
+
+        `node_type` must be `NodeType.RACK_CONTROLLER` or
+        `NodeType.REGION_AND_RACK_CONTROLLER`.
+        """
+        from .controllers import RackController
+        if self.node_type not in [
+                NodeType.RACK_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER]:
+            raise ValueError(
+                'Cannot convert to `RackController`, node_type is not a '
+                'rack controller.')
+        return RackController(self._data)
+
+    def as_region_controller(self):
+        """Convert to a `RegionController` object.
+
+        `node_type` must be `NodeType.REGION_CONTROLLER` or
+        `NodeType.REGION_AND_RACK_CONTROLLER`.
+        """
+        from .controllers import RegionController
+        if self.node_type not in [
+                NodeType.REGION_CONTROLLER,
+                NodeType.REGION_AND_RACK_CONTROLLER]:
+            raise ValueError(
+                'Cannot convert to `RegionController`, node_type is not a '
+                'region controller.')
+        return RegionController(self._data)

--- a/maas/client/viscera/tests/test.py
+++ b/maas/client/viscera/tests/test.py
@@ -339,7 +339,8 @@ class TestObject(TestCase):
             })
         error = self.assertRaises(TypeError, object_type, 0)
         self.assertThat(
-            str(error), Equals("data must be a sequence, not int"))
+            str(error),
+            Equals("data must be a mapping or a sequence, not int"))
 
     def test__init_validates_property_when_multiple_pks(self):
         object_type = type(

--- a/maas/client/viscera/tests/test_nodes.py
+++ b/maas/client/viscera/tests/test_nodes.py
@@ -3,11 +3,18 @@
 from testtools.matchers import Equals
 
 from .. import nodes
+from ..controllers import (
+    RackController,
+    RegionController,
+)
+from ..devices import Device
+from ..machines import Machine
+from ..testing import bind
+from ...enum import NodeType
 from ...testing import (
     make_name_without_spaces,
     TestCase,
 )
-from ..testing import bind
 
 
 def make_origin():
@@ -39,6 +46,148 @@ class TestNode(TestCase):
         node_observed = origin.Node.read(data["system_id"])
         node_expected = origin.Node(data)
         self.assertThat(node_observed, Equals(node_expected))
+
+    def test__as_machine_requires_machine_type(self):
+        device_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.DEVICE.value,
+        })
+        rack_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.RACK_CONTROLLER.value,
+        })
+        region_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.REGION_CONTROLLER.value,
+        })
+        region_rack_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.REGION_AND_RACK_CONTROLLER.value,
+        })
+        self.assertRaises(ValueError, device_node.as_machine)
+        self.assertRaises(ValueError, rack_node.as_machine)
+        self.assertRaises(ValueError, region_node.as_machine)
+        self.assertRaises(ValueError, region_rack_node.as_machine)
+
+    def test__as_machine_returns_machine_type(self):
+        machine_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.MACHINE.value,
+        })
+        machine = machine_node.as_machine()
+        self.assertIsInstance(machine, Machine)
+
+    def test__as_device_requires_device_type(self):
+        machine_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.MACHINE.value,
+        })
+        rack_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.RACK_CONTROLLER.value,
+        })
+        region_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.REGION_CONTROLLER.value,
+        })
+        region_rack_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.REGION_AND_RACK_CONTROLLER.value,
+        })
+        self.assertRaises(ValueError, machine_node.as_device)
+        self.assertRaises(ValueError, rack_node.as_device)
+        self.assertRaises(ValueError, region_node.as_device)
+        self.assertRaises(ValueError, region_rack_node.as_device)
+
+    def test__as_device_returns_device_type(self):
+        device_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.DEVICE.value,
+        })
+        device = device_node.as_device()
+        self.assertIsInstance(device, Device)
+
+    def test__as_rack_controller_requires_rack_types(self):
+        machine_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.MACHINE.value,
+        })
+        device_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.DEVICE.value,
+        })
+        region_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.REGION_CONTROLLER.value,
+        })
+        self.assertRaises(ValueError, machine_node.as_rack_controller)
+        self.assertRaises(ValueError, device_node.as_rack_controller)
+        self.assertRaises(ValueError, region_node.as_rack_controller)
+
+    def test__as_rack_controller_returns_rack_type(self):
+        rack_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.RACK_CONTROLLER.value,
+        })
+        region_rack_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.REGION_AND_RACK_CONTROLLER.value,
+        })
+        rack = rack_node.as_rack_controller()
+        region_rack = region_rack_node.as_rack_controller()
+        self.assertIsInstance(rack, RackController)
+        self.assertIsInstance(region_rack, RackController)
+
+    def test__as_region_controller_requires_region_types(self):
+        machine_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.MACHINE.value,
+        })
+        device_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.DEVICE.value,
+        })
+        rack_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.RACK_CONTROLLER.value,
+        })
+        self.assertRaises(ValueError, machine_node.as_region_controller)
+        self.assertRaises(ValueError, device_node.as_region_controller)
+        self.assertRaises(ValueError, rack_node.as_region_controller)
+
+    def test__as_region_controller_returns_region_type(self):
+        region_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.REGION_CONTROLLER.value,
+        })
+        region_rack_node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+            "node_type": NodeType.REGION_AND_RACK_CONTROLLER.value,
+        })
+        region = region_node.as_region_controller()
+        region_rack = region_rack_node.as_region_controller()
+        self.assertIsInstance(region, RegionController)
+        self.assertIsInstance(region_rack, RegionController)
 
 
 class TestNodes(TestCase):

--- a/maas/client/viscera/tests/test_nodes.py
+++ b/maas/client/viscera/tests/test_nodes.py
@@ -1,0 +1,57 @@
+"""Test for `maas.client.viscera.nodes`."""
+
+from testtools.matchers import Equals
+
+from .. import nodes
+from ...testing import (
+    make_name_without_spaces,
+    TestCase,
+)
+from ..testing import bind
+
+
+def make_origin():
+    # Create a new origin with Nodes and Node. The former refers to the
+    # latter via the origin, hence why it must be bound.
+    return bind(nodes.Nodes, nodes.Node)
+
+
+class TestNode(TestCase):
+
+    def test__string_representation_includes_only_system_id_and_hostname(self):
+        node = nodes.Node({
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+        })
+        self.assertThat(repr(node), Equals(
+            "<Node hostname=%(hostname)r system_id=%(system_id)r>"
+            % node._data))
+
+    def test__read(self):
+        data = {
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+        }
+
+        origin = make_origin()
+        origin.Node._handler.read.return_value = data
+
+        node_observed = origin.Node.read(data["system_id"])
+        node_expected = origin.Node(data)
+        self.assertThat(node_observed, Equals(node_expected))
+
+
+class TestNodes(TestCase):
+
+    def test__read(self):
+        data = {
+            "system_id": make_name_without_spaces("system-id"),
+            "hostname": make_name_without_spaces("hostname"),
+        }
+
+        origin = make_origin()
+        origin.Nodes._handler.read.return_value = [data]
+
+        nodes_observed = origin.Nodes.read()
+        nodes_expected = origin.Nodes([origin.Node(data)])
+        self.assertThat(nodes_observed, Equals(nodes_expected))

--- a/maas/client/viscera/users.py
+++ b/maas/client/viscera/users.py
@@ -39,18 +39,25 @@ class Users(ObjectSet, metaclass=UsersType):
     """The set of users."""
 
 
-class User(Object):
+class UserType(ObjectType):
+
+    async def read(cls, username):
+        data = await cls._handler.read(username=username)
+        return cls(data)
+
+
+class User(Object, metaclass=UserType):
     """A user."""
 
     username = ObjectField.Checked(
-        "username", check(str), check(str))
+        "username", check(str), check(str), pk=True)
     email = ObjectField.Checked(
         "email", check(str), check(str))
     is_admin = ObjectField.Checked(
         "is_superuser", check(bool), check(bool))
 
     def __repr__(self):
-        if self.is_admin:
+        if self.loaded and self.is_admin:
             return super(User, self).__repr__(
                 name="Admin", fields={"username"})
         else:


### PR DESCRIPTION
Add ability for alternative primary keys to be defined for an object. This allows objects to reference other objects with a primary key that is not the actual main key over the API. E.g. You can reference an `Interface` by its `system_id` and `id` or `name`.

Refactor all node based objects to extend from a `Node` and `Nodes` classes to easy development and allow a user to reference a generic node.

Add ability for a generic `Node` to be converted into its actual object type: `Machine`, `Device`, `RackController`, or `RegionController`.

Add ability for a `Node` including all subclasses to reference the `owner` as an object of `User`. 

 