### PR TITLE
Add ability to create all interface types, delete an interface, and update all fields on an interface.

### DIFF
--- a/doc.yaml
+++ b/doc.yaml
@@ -14,6 +14,7 @@ pages:
     - Introduction: client/index.md
     - Nodes: client/nodes.md
     - Networking: client/networking.md
+    - Interfaces: client/interfaces.md
     - Events: client/events.md
     - Others: client/other.md
   - Internals:

--- a/doc/client/interfaces.md
+++ b/doc/client/interfaces.md
@@ -1,0 +1,143 @@
+<h1>Interfaces</h1>
+
+Given an ``Node`` instance bound to your MAAS server, you can
+view and modify its interface configuration. This applies to all ``Machine``,
+``Device``, ``RackController``, and ``RegionController``.
+
+## Read interfaces
+
+All ``Node`` objects have an ``interfaces`` property that provide a sequence of
+all ``Interface``'s on the ``Node``.
+
+```pycon
+>>> machine.interfaces
+<Interfaces.Managed#Machine length=1 items=[
+  <Interface mac_address='52:54:00:b4:7e:8c' name='ens3'
+    type=<InterfaceType.PHYSICAL: 'physical'>>]>
+>>> machine.boot_interface
+<Interface mac_address='52:54:00:b4:7e:8c' name='ens3'
+  type=<InterfaceType.PHYSICAL: 'physical'>>
+```
+
+On bond, VLAN, and bridge interfaces you can get the parents that make the
+interface. You can also go the other direction and view the children interfaces
+that are using this interface.
+
+**Note:** Parent and children objects are unloaded so they must be loaded to
+access the properties of the object.
+
+```pycon
+>>> bond.parents
+<Interfaces.Managed#Interface length=2 items=[
+  <Interface name='ens3'
+    node=<Node system_id='yr7fym' (unloaded)> (unloaded)>,
+  <Interface name='ens4'
+    node=<Node system_id='yr7fym' (unloaded)> (unloaded)>,
+  ]>
+>>> ens3 = bond.parents[0]
+>>> ens3.loaded
+False
+>>> ens3.refresh()
+>>> ens3.type
+<InterfaceType.PHYSICAL: 'physical'>
+>>> ens3.children
+<Interfaces.Managed#Interface length=1 items=[
+  <Interface name='bond0'
+    node=<Node system_id='yr7fym' (unloaded)> (unloaded)>,
+  ]>
+```
+
+## Create physical
+
+Creation of interfaces is done directly on the ``interfaces`` property of a
+``Node``. Physical interface is the default type for the ``create`` method so
+only ``mac_address`` is required.
+
+```pycon
+>>> new_phy = machine.interfaces.create(mac_address="00:11:22:aa:bb:cc")
+>>> new_phy
+<Interface mac_address='00:11:22:aa:bb:cc' name='eth0'
+  type=<InterfaceType.PHYSICAL: 'physical'>>
+```
+
+By default the interface is created disconnected. To create it the interface
+with it connected to a VLAN pass the ``vlan`` parameter.
+
+```pycon
+>>> default_vlan = client.fabrics.get_default().vlans.get_default()
+>>> new_phy = machine.interfaces.create(
+...    mac_address="00:11:22:aa:bb:cc", vlan=default_vlan)
+>>> new_phy
+<Interface mac_address='00:11:22:aa:bb:cc' name='eth0'
+  type=<InterfaceType.PHYSICAL: 'physical'>>
+>>> new_phy.vlan
+<Vlan name='untagged' vid=0>
+```
+
+## Create bond
+
+Bond creation is the same as creating a physical interface but an
+``InterfaceType`` is provided with options specific for a bond.
+
+```pycon
+>>> new_bond = machine.interfaces.create(
+...    InterfaceType.BOND, name='bond0', parents=machine.interfaces,
+...    bond_mode='802.3ad')
+>>> new_bond
+<Interface mac_address='52:54:00:b4:7e:8c' name='bond0'
+  type=<InterfaceType.BOND: 'bond'>>
+>>> new_bond.params
+{'bond_downdelay': 0,
+ 'bond_lacp_rate': 'slow',
+ 'bond_miimon': 100,
+ 'bond_mode': '802.3ad',
+ 'bond_updelay': 0,
+ 'bond_xmit_hash_policy': 'layer2'}
+```
+
+## Create vlan
+
+VLAN creation only requires a single parent and a tagged VLAN to connect
+the interface to.
+
+```pycon
+>>> default_fabric = client.fabrics.get_default()
+>>> vlan_10 = default_fabric.vlans.create(10)
+>>> vlan_nic = machine.interfaces.create(
+...     InterfaceType.VLAN, parent=new_bond, vlan=vlan_10)
+>>> vlan_nic
+<Interface mac_address='52:54:00:b4:7e:8c' name='bond0.10'
+  type=<InterfaceType.VLAN: 'vlan'>>
+```
+
+## Create bridge
+
+Bridge creation only requires the name and parent interface you want the
+bridge to be created on.
+
+```pycon
+>>> bridge_nic = machine.interfaces.create(
+...     InterfaceType.BRIDGE, name='br0', parent=vlan_nic)
+>>> bridge_nic
+<Interface mac_address='52:54:00:b4:7e:8c' name='br0'
+  type=<InterfaceType.BRIDGE: 'bridge'>>
+```
+
+## Update interface
+
+To update an interface just changing the properties of the interface and
+calling ``save`` is all that is required.
+
+```pycon
+>>> new_bond.name = 'my-bond'
+>>> new_bond.params['bond_mode'] = 'active-backup'
+>>> new_bond.save()
+```
+
+## Delete interface
+
+``delete`` exists directly on the ``Interface`` object so deletion is simple.
+
+```pycon
+>>> new_bond.delete()
+```

--- a/maas/client/enum.py
+++ b/maas/client/enum.py
@@ -104,3 +104,16 @@ class IPRangeType(enum.Enum):
     DYNAMIC = 'dynamic'
     #: Reserved for exclusive use by MAAS or user.
     RESERVED = 'reserved'
+
+
+class InterfaceType(enum.Enum):
+    #: Physical interface.
+    PHYSICAL = 'physical'
+    #: Bonded interface.
+    BOND = 'bond'
+    #: Bridge interface.
+    BRIDGE = 'bridge'
+    #: VLAN interface.
+    VLAN = 'vlan'
+    #: Interface not linked to a node.
+    UNKNOWN = 'unknown'

--- a/maas/client/utils/__init__.py
+++ b/maas/client/utils/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Utilities for the MAAS client."""
 
 __all__ = [
@@ -306,6 +320,15 @@ def coalesce(*values, default=None):
             return value
     else:
         return default
+
+
+def remove_None(params: dict):
+    """Remove all keys in `params` that have the value of `None`."""
+    return {
+        key: value
+        for key, value in params.items()
+        if value is not None
+    }
 
 
 class Spinner:

--- a/maas/client/utils/async.py
+++ b/maas/client/utils/async.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Canonical Ltd.
+# Copyright 2016-2017 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/maas/client/utils/auth.py
+++ b/maas/client/utils/auth.py
@@ -1,3 +1,17 @@
+# Copyright 2016 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """MAAS CLI authentication."""
 
 __all__ = [

--- a/maas/client/utils/creds.py
+++ b/maas/client/utils/creds.py
@@ -1,3 +1,17 @@
+# Copyright 2016 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Handling of MAAS API credentials.
 
 The API client deals with credentials consisting of 3 elements: consumer key,

--- a/maas/client/utils/diff.py
+++ b/maas/client/utils/diff.py
@@ -1,0 +1,36 @@
+"""Helpers for calulating difference between objects."""
+
+__all__ = [
+    "calculate_dict_diff",
+]
+
+
+def remove_None(params: dict):
+    """Remove all keys in `params` that have the value of `None`."""
+    return {
+        key: value
+        for key, value in params.items()
+        if value is not None
+    }
+
+
+def calculate_dict_diff(old_params: dict, new_params: dict):
+    """Return the parameters based on the difference.
+
+    If a parameter exists in `old_params` but not in `new_params` then
+    parameter will be set to an empty string.
+    """
+    # Ignore all None values as those cannot be saved.
+    old_params = remove_None(old_params)
+    new_params = remove_None(new_params)
+    params_diff = {}
+    for key, value in old_params.items():
+        if key in new_params:
+            if value != new_params[key]:
+                params_diff[key] = new_params[key]
+        else:
+            params_diff[key] = ''
+    for key, value in new_params.items():
+        if key not in old_params:
+            params_diff[key] = value
+    return params_diff

--- a/maas/client/utils/diff.py
+++ b/maas/client/utils/diff.py
@@ -1,3 +1,17 @@
+# Copyright 2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Helpers for calulating difference between objects."""
 
 __all__ = [
@@ -5,13 +19,7 @@ __all__ = [
 ]
 
 
-def remove_None(params: dict):
-    """Remove all keys in `params` that have the value of `None`."""
-    return {
-        key: value
-        for key, value in params.items()
-        if value is not None
-    }
+from . import remove_None
 
 
 def calculate_dict_diff(old_params: dict, new_params: dict):

--- a/maas/client/utils/multipart.py
+++ b/maas/client/utils/multipart.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Encoding of MIME multipart data."""
 
 __all__ = [

--- a/maas/client/utils/profiles.py
+++ b/maas/client/utils/profiles.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Profile configuration."""
 
 __all__ = [

--- a/maas/client/utils/tests/test.py
+++ b/maas/client/utils/tests/test.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for `maas.client.utils`."""
 
 import base64
@@ -439,3 +453,15 @@ class TestRetries(TestCase):
         self.assertRetry(clock, next(gen_retries), 103.5, -98.5, 0.0)
         # All done.
         self.assertRaises(StopIteration, next, gen_retries)
+
+
+class TestRemoveNone(TestCase):
+    """Test `remove_None`."""
+
+    def test_removes_all_None_values(self):
+        data = {
+            'None': None,
+            'another_None': None,
+            'keep': 'value'
+        }
+        self.assertEquals({'keep': 'value'}, utils.remove_None(data))

--- a/maas/client/utils/tests/test_auth.py
+++ b/maas/client/utils/tests/test_auth.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for `maas.client.utils.auth`."""
 
 import sys

--- a/maas/client/utils/tests/test_creds.py
+++ b/maas/client/utils/tests/test_creds.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for handling of MAAS API credentials."""
 
 from testtools.matchers import IsInstance

--- a/maas/client/utils/tests/test_diff.py
+++ b/maas/client/utils/tests/test_diff.py
@@ -1,0 +1,65 @@
+# Copyright 2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for handling the calculation of object difference."""
+
+import copy
+
+from ...testing import TestCase
+from ..diff import calculate_dict_diff
+
+
+class TestCalculateDictDiff(TestCase):
+    """Test `calculate_dict_diff`."""
+
+    def test_calcs_no_difference(self):
+        orig_data = {
+            'key1': 'value1',
+            'key2': 'value2',
+        }
+        new_data = copy.deepcopy(orig_data)
+        self.assertEquals({}, calculate_dict_diff(orig_data, new_data))
+
+    def test_calcs_changed_value(self):
+        orig_data = {
+            'key1': 'value1',
+            'key2': 'value2',
+        }
+        new_data = copy.deepcopy(orig_data)
+        new_data['key2'] = 'new_value'
+        self.assertEquals(
+            {'key2': 'new_value'}, calculate_dict_diff(orig_data, new_data))
+
+    def test_calcs_deleted_value(self):
+        orig_data = {
+            'key1': 'value1',
+            'key2': 'value2',
+        }
+        new_data = copy.deepcopy(orig_data)
+        del new_data['key2']
+        self.assertEquals(
+            {'key2': ''}, calculate_dict_diff(orig_data, new_data))
+
+    def test_calcs_changes_and_deleted(self):
+        orig_data = {
+            'key1': 'value1',
+            'key2': 'value2',
+        }
+        new_data = copy.deepcopy(orig_data)
+        new_data['key1'] = 'new_value'
+        del new_data['key2']
+        self.assertEquals({
+            'key1': 'new_value',
+            'key2': '',
+        }, calculate_dict_diff(orig_data, new_data))

--- a/maas/client/utils/tests/test_multipart.py
+++ b/maas/client/utils/tests/test_multipart.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Test multipart MIME helpers."""
 
 from io import BytesIO

--- a/maas/client/utils/tests/test_profiles.py
+++ b/maas/client/utils/tests/test_profiles.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for `maas.client.utils.profiles`."""
 
 import contextlib

--- a/maas/client/utils/types.py
+++ b/maas/client/utils/types.py
@@ -1,3 +1,17 @@
+# Copyright 2016-2017 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Miscellaneous types."""
 
 __all__ = [

--- a/maas/client/viscera/interfaces.py
+++ b/maas/client/viscera/interfaces.py
@@ -5,7 +5,7 @@ __all__ = [
     "Interfaces",
 ]
 
-from typing import Sequence, Union
+from typing import Iterable, Union
 
 from . import (
     check,
@@ -164,9 +164,9 @@ class InterfacesType(ObjectType):
     async def create(
             cls, node: Union[Node, str],
             interface_type: InterfaceType=InterfaceType.PHYSICAL, *,
-            name: str=None, mac_address: str=None, tags: Sequence[str]=None,
+            name: str=None, mac_address: str=None, tags: Iterable[str]=None,
             vlan: Union[Vlan, int]=None, parent: Union[Interface, int]=None,
-            parents: Sequence[Union[Interface, int]]=None, mtu: int=None,
+            parents: Iterable[Union[Interface, int]]=None, mtu: int=None,
             accept_ra: bool=None, autoconf: bool=None,
             bond_mode: str=None, bond_miimon: int=None,
             bond_downdelay: int=None, bond_updelay: int=None,
@@ -289,9 +289,9 @@ class InterfacesType(ObjectType):
             handler = cls._handler.create_bond
             if parent is not None:
                 raise ValueError("use parents not parent for bond interface")
-            if not isinstance(parents, Sequence):
+            if not isinstance(parents, Iterable):
                 raise TypeError(
-                    'parents must be a sequence, not %s' % (
+                    'parents must be a iterable, not %s' % (
                         type(parents).__name__))
             if len(parents) == 0:
                 raise ValueError(

--- a/maas/client/viscera/interfaces.py
+++ b/maas/client/viscera/interfaces.py
@@ -5,6 +5,8 @@ __all__ = [
     "Interfaces",
 ]
 
+from typing import Sequence, Union
+
 from . import (
     check,
     Object,
@@ -13,53 +15,52 @@ from . import (
     ObjectFieldRelatedSet,
     ObjectSet,
     ObjectType,
+    to,
 )
-from .machines import Machine
-from .devices import Device
-from .controllers import (
-    RackController,
-    RegionController,
-)
+from .nodes import Node
+from .vlans import Vlan
+from ..enum import InterfaceType
+from ..utils.diff import calculate_dict_diff
 
 
-class InterfacesType(ObjectType):
-    """Metaclass for `Interfaces`."""
-
-    async def read(cls, node):
-        """Get list of `Interface`'s for `node`."""
-        if isinstance(node, str):
-            system_id = node
-        elif isinstance(
-                node, (Device, Machine, RackController, RegionController)):
-            system_id = node.system_id
+def gen_parents(parents):
+    """Generate the parents to send to the handler."""
+    for idx, parent in enumerate(parents):
+        if isinstance(parent, Interface):
+            parent = parent.id
+        elif isinstance(parent, int):
+            pass
         else:
             raise TypeError(
-                "node must be a Machine or str, not %s"
-                % type(node).__name__)
-        data = await cls._handler.read(system_id=system_id)
-        return cls(
-            cls._object(
-                item, local_data={"node_system_id": system_id})
-            for item in data)
+                'parent[%d] must be Interface or int, not %s' % (
+                    idx, type(parent).__class__))
+        yield parent
 
 
-class Interfaces(ObjectSet, metaclass=InterfacesType):
-    """The set of interfaces on a machine."""
+def get_parent(parent):
+    """Get the parent to send to the handler."""
+    if isinstance(parent, Interface):
+        return parent.id
+    elif isinstance(parent, int):
+        return parent
+    else:
+        raise TypeError(
+            "parent must be Interface or int, not %s" % (
+                type(parent).__class__))
 
 
-class InterfaceType(ObjectType):
+class InterfaceTypeMeta(ObjectType):
     """Metaclass for `Interface`."""
 
     async def read(cls, node, id):
         """Get `Interface` by `id`."""
         if isinstance(node, str):
             system_id = node
-        elif isinstance(
-                node, (Device, Machine, RackController, RegionController)):
+        elif isinstance(node, Node):
             system_id = node.system_id
         else:
             raise TypeError(
-                "node must be a Machine or str, not %s"
+                "node must be a Node or str, not %s"
                 % type(node).__name__)
         data = await cls._handler.read(system_id=system_id, id=id)
         return cls(data, {"node_system_id": system_id})
@@ -81,7 +82,7 @@ def map_nic_name_to_dict(instance, value):
     }
 
 
-class Interface(Object, metaclass=InterfaceType):
+class Interface(Object, metaclass=InterfaceTypeMeta):
     """A interface on a machine."""
 
     node = ObjectFieldRelated(
@@ -89,7 +90,7 @@ class Interface(Object, metaclass=InterfaceType):
     id = ObjectField.Checked(
         "id", check(int), readonly=True, pk=1)
     type = ObjectField.Checked(
-        "type", check(str), readonly=True)
+        "type", to(InterfaceType), readonly=True)
     name = ObjectField.Checked(
         "name", check(str), check(str), alt_pk=1)
     mac_address = ObjectField.Checked(
@@ -108,11 +109,241 @@ class Interface(Object, metaclass=InterfaceType):
     children = ObjectFieldRelatedSet(
         "children", "Interfaces", reverse=None,
         map_func=map_nic_name_to_dict)
-    vlan = ObjectFieldRelated("vlan", "Vlan", reverse=None)
+    vlan = ObjectFieldRelated(
+        "vlan", "Vlan", reverse=None, use_data_setter=True)
 
     # links
     # discovered
 
     def __repr__(self):
         return super(Interface, self).__repr__(
-            fields={"name", "mac_address"})
+            fields={"name", "mac_address", "type"})
+
+    async def save(self):
+        """Save this interface."""
+        if set(self.tags) != set(self._orig_data['tags']):
+            self._changed_data['tags'] = ','.join(self.tags)
+        self._changed_data.update(
+            calculate_dict_diff(self._orig_data['params'], self.params))
+        if 'vlan' in self._changed_data and self._changed_data['vlan']:
+            # Update uses the ID of the VLAN, not the VLAN object.
+            self._changed_data['vlan'] = self._changed_data['vlan']['id']
+            if (self._orig_data['vlan'] and
+                    'id' in self._orig_data['vlan'] and
+                    self._changed_data['vlan'] == (
+                        self._orig_data['vlan']['id'])):
+                # VLAN didn't really change, the object was just set to the
+                # same VLAN.
+                del self._changed_data['vlan']
+        await super(Interface, self).save()
+
+    async def delete(self):
+        """Delete this interface."""
+        await self._handler.delete(
+            system_id=self.node.system_id, id=self.id)
+
+
+class InterfacesType(ObjectType):
+    """Metaclass for `Interfaces`."""
+
+    async def read(cls, node):
+        """Get list of `Interface`'s for `node`."""
+        if isinstance(node, str):
+            system_id = node
+        elif isinstance(node, Node):
+            system_id = node.system_id
+        else:
+            raise TypeError(
+                "node must be a Node or str, not %s"
+                % type(node).__name__)
+        data = await cls._handler.read(system_id=system_id)
+        return cls(
+            cls._object(
+                item, local_data={"node_system_id": system_id})
+            for item in data)
+
+    async def create(
+            cls, node: Union[Node, str],
+            interface_type: InterfaceType=InterfaceType.PHYSICAL, *,
+            name: str=None, mac_address: str=None, tags: Sequence[str]=None,
+            vlan: Union[Vlan, int]=None, parent: Union[Interface, int]=None,
+            parents: Sequence[Union[Interface, int]]=None, mtu: int=None,
+            accept_ra: bool=None, autoconf: bool=None,
+            bond_mode: str=None, bond_miimon: int=None,
+            bond_downdelay: int=None, bond_updelay: int=None,
+            bond_lacp_rate: str=None, bond_xmit_hash_policy: str=None,
+            bridge_stp: bool=None, bridge_fd: int=None):
+        """
+        Create a `Interface` in MAAS.
+
+        :param node: Node to create the interface on.
+        :type node: `Node` or `str`
+        :param interface_type: Type of interface to create (optional).
+        :type interface_type: `InterfaceType`
+        :param name: The name for the interface (optional).
+        :type name: `str`
+        :param tags: List of tags to add to the machine.
+        :type tags: sequence of `str`
+        :param mtu: The MTU for the interface (optional).
+        :type mtu: `int`
+        :param vlan: VLAN the interface is connected to (optional).
+        :type vlan: `Vlan` or `int`
+        :param accept_ra: True if the interface should accepted router
+            advertisements. (optional)
+        :type accept_ra: `bool`
+        :param autoconf: True if the interface should auto configure.
+        :type autoconf: `bool`
+
+        Following parameters specific to physical interface.
+
+        :param mac_address: The MAC address for the interface.
+        :type mac_address: `str`
+
+        Following parameters specific to a bond interface.
+
+        :param parents: Parent interfaces that make up the bond.
+        :type parents: sequence of `Interface` or `int`
+        :param mac_address: MAC address to use for the bond (optional).
+        :type mac_address: `str`
+        :param bond_mode: The operating mode of the bond (optional).
+        :type bond_mode: `str`
+        :param bond_miimon: The link monitoring freqeuncy in
+            milliseconds (optional).
+        :type bond_miimon: `int`
+        :param bond_downdelay: Specifies the time, in milliseconds, to wait
+            before disabling a slave after a link failure has been detected
+            (optional).
+        :type bond_downdelay: `int`
+        :param bond_updelay: Specifies the time, in milliseconds, to wait
+            before enabling a slave after a link recovery has been detected.
+        :type bond_updelay: `int`
+        :param bond_lacp_rate: Option specifying the rate in which we'll ask
+            our link partner to transmit LACPDU packets in 802.3ad
+            mode (optional).
+        :type bond_lacp_rate: `str`
+        :param bond_xmit_hash_policy: The transmit hash policy to use for
+            slave selection in balance-xor, 802.3ad, and tlb modes(optional).
+        :type bond_xmit_hash_policy: `str`
+
+        Following parameters specific to a VLAN interface.
+
+        :param parent: Parent interface for this VLAN interface.
+        :type parent: `Interface` or `int`
+
+        Following parameters specific to a Bridge interface.
+
+        :param parent: Parent interface for this bridge interface.
+        :type parent: `Interface` or `int`
+        :param mac_address: The MAC address for the interface (optional).
+        :type mac_address: `str`
+        :param bridge_stp: Turn spanning tree protocol on or off (optional).
+        :type bridge_stp: `bool`
+        :param bridge_fd: Set bridge forward delay to time seconds (optional).
+        :type bridge_fd: `int`
+
+        :returns: The created Interface.
+        :rtype: `Interface`
+        """
+        params = {}
+        if isinstance(node, str):
+            params['system_id'] = node
+        elif isinstance(node, Node):
+            params['system_id'] = node.system_id
+        else:
+            raise TypeError(
+                'node must be Node or str, not %s' % (
+                    type(node).__name__))
+
+        if name is not None:
+            params['name'] = name
+        if tags is not None:
+            params['tags'] = tags
+        if mtu is not None:
+            params['mtu'] = mtu
+        if vlan is not None:
+            if isinstance(vlan, Vlan):
+                params['vlan'] = vlan.id
+            elif isinstance(vlan, int):
+                params['vlan'] = vlan
+            else:
+                raise TypeError(
+                    'vlan must be Vlan or int, not %s' % (
+                        type(vlan).__name__))
+        if accept_ra is not None:
+            params['accept_ra'] = accept_ra
+        if autoconf is not None:
+            params['autoconf'] = autoconf
+
+        handler = None
+        if not isinstance(interface_type, InterfaceType):
+            raise TypeError(
+                'interface_type must be InterfaceType, not %s' % (
+                    type(interface_type).__name__))
+        if interface_type == InterfaceType.PHYSICAL:
+            handler = cls._handler.create_physical
+            if mac_address:
+                params['mac_address'] = mac_address
+            else:
+                raise ValueError(
+                    'mac_address required for physical interface')
+        elif interface_type == InterfaceType.BOND:
+            handler = cls._handler.create_bond
+            if parent is not None:
+                raise ValueError("use parents not parent for bond interface")
+            if not isinstance(parents, Sequence):
+                raise TypeError(
+                    'parents must be a sequence, not %s' % (
+                        type(parents).__name__))
+            if len(parents) == 0:
+                raise ValueError(
+                    'at least one parent required for bond interface')
+            params['parents'] = list(gen_parents(parents))
+            if not name:
+                raise ValueError('name is required for bond interface')
+            if mac_address is not None:
+                params['mac_address'] = mac_address
+            if bond_mode is not None:
+                params['bond_mode'] = bond_mode
+            if bond_miimon is not None:
+                params['bond_miimon'] = bond_miimon
+            if bond_downdelay is not None:
+                params['bond_downdelay'] = bond_downdelay
+            if bond_updelay is not None:
+                params['bond_updelay'] = bond_updelay
+            if bond_lacp_rate is not None:
+                params['bond_lacp_rate'] = bond_lacp_rate
+            if bond_xmit_hash_policy is not None:
+                params['bond_xmit_hash_policy'] = bond_xmit_hash_policy
+        elif interface_type == InterfaceType.VLAN:
+            handler = cls._handler.create_vlan
+            if parents is not None:
+                raise ValueError("use parent not parents for VLAN interface")
+            if parent is None:
+                raise ValueError("parent is required for VLAN interface")
+            params['parent'] = get_parent(parent)
+            if vlan is None:
+                raise ValueError("vlan is required for VLAN interface")
+        elif interface_type == InterfaceType.BRIDGE:
+            handler = cls._handler.create_bridge
+            if parents is not None:
+                raise ValueError("use parent not parents for bridge interface")
+            if parent is None:
+                raise ValueError("parent is required for bridge interface")
+            params['parent'] = get_parent(parent)
+            if not name:
+                raise ValueError('name is required for bridge interface')
+            if mac_address is not None:
+                params['mac_address'] = mac_address
+            if bridge_stp is not None:
+                params['bridge_stp'] = bridge_stp
+            if bridge_fd is not None:
+                params['bridge_fd'] = bridge_fd
+        else:
+            raise ValueError(
+                "cannot create an interface of type: %s" % interface_type)
+
+        return cls._object(await handler(**params))
+
+
+class Interfaces(ObjectSet, metaclass=InterfacesType):
+    """The set of interfaces on a machine."""

--- a/maas/client/viscera/interfaces.py
+++ b/maas/client/viscera/interfaces.py
@@ -122,6 +122,8 @@ class Interface(Object, metaclass=InterfaceTypeMeta):
         """Save this interface."""
         if set(self.tags) != set(self._orig_data['tags']):
             self._changed_data['tags'] = ','.join(self.tags)
+        elif 'tags' in self._changed_data:
+            del self._changed_data['tags']
         self._changed_data.update(
             calculate_dict_diff(self._orig_data['params'], self.params))
         if 'vlan' in self._changed_data and self._changed_data['vlan']:

--- a/maas/client/viscera/interfaces.py
+++ b/maas/client/viscera/interfaces.py
@@ -32,8 +32,8 @@ def gen_parents(parents):
             pass
         else:
             raise TypeError(
-                'parent[%d] must be Interface or int, not %s' % (
-                    idx, type(parent).__class__))
+                'parent[%d] must be an Interface or int, not %s' % (
+                    idx, type(parent).__name__))
         yield parent
 
 
@@ -45,8 +45,8 @@ def get_parent(parent):
         return parent
     else:
         raise TypeError(
-            "parent must be Interface or int, not %s" % (
-                type(parent).__class__))
+            "parent must be an Interface or int, not %s" % (
+                type(parent).__name__))
 
 
 class InterfaceTypeMeta(ObjectType):
@@ -62,8 +62,7 @@ class InterfaceTypeMeta(ObjectType):
             raise TypeError(
                 "node must be a Node or str, not %s"
                 % type(node).__name__)
-        data = await cls._handler.read(system_id=system_id, id=id)
-        return cls(data, {"node_system_id": system_id})
+        return cls(await cls._handler.read(system_id=system_id, id=id))
 
 
 def map_nic_name_to_dict(instance, value):
@@ -251,7 +250,7 @@ class InterfacesType(ObjectType):
             params['system_id'] = node.system_id
         else:
             raise TypeError(
-                'node must be Node or str, not %s' % (
+                'node must be a Node or str, not %s' % (
                     type(node).__name__))
 
         if name is not None:
@@ -267,7 +266,7 @@ class InterfacesType(ObjectType):
                 params['vlan'] = vlan
             else:
                 raise TypeError(
-                    'vlan must be Vlan or int, not %s' % (
+                    'vlan must be a Vlan or int, not %s' % (
                         type(vlan).__name__))
         if accept_ra is not None:
             params['accept_ra'] = accept_ra
@@ -277,7 +276,7 @@ class InterfacesType(ObjectType):
         handler = None
         if not isinstance(interface_type, InterfaceType):
             raise TypeError(
-                'interface_type must be InterfaceType, not %s' % (
+                'interface_type must be an InterfaceType, not %s' % (
                     type(interface_type).__name__))
         if interface_type == InterfaceType.PHYSICAL:
             handler = cls._handler.create_physical

--- a/maas/client/viscera/tests/test_interfaces.py
+++ b/maas/client/viscera/tests/test_interfaces.py
@@ -1,0 +1,614 @@
+"""Test for `maas.client.viscera.interfaces`."""
+
+import random
+
+from testtools.matchers import (
+    Equals,
+    IsInstance,
+)
+
+from ..fabrics import (
+    Fabric,
+    Fabrics,
+)
+from ..interfaces import (
+    Interface,
+    Interfaces,
+)
+from ..nodes import (
+    Node,
+    Nodes,
+)
+from ..vlans import (
+    Vlan,
+    Vlans,
+)
+
+from .. testing import bind
+from ...enum import InterfaceType
+from ...testing import (
+    make_string_without_spaces,
+    TestCase,
+)
+
+
+def make_origin():
+    """
+    Create a new origin with required objects.
+    """
+    return bind(
+        Fabrics, Fabric, Interfaces, Interface, Nodes, Node, Vlans, Vlan)
+
+
+class TestInterfaces(TestCase):
+
+    def test__read_bad_node_type(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            TypeError, Interfaces.read, random.randint(0, 100))
+        self.assertEquals("node must be a Node or str, not int", str(error))
+
+    def test__read_with_system_id(self):
+        Interfaces = make_origin().Interfaces
+        system_id = make_string_without_spaces()
+        interfaces = [
+            {
+                "system_id": system_id,
+                "id": random.randint(0, 100),
+                "name": make_string_without_spaces(),
+                "type": InterfaceType.PHYSICAL.value,
+            }
+            for _ in range(3)
+        ]
+        Interfaces._handler.read.return_value = interfaces
+        interfaces = Interfaces.read(system_id)
+        self.assertThat(len(interfaces), Equals(3))
+        Interfaces._handler.read.assert_called_once_with(system_id=system_id)
+
+    def test__read_with_Node(self):
+        origin = make_origin()
+        Interfaces, Node = origin.Interfaces, origin.Node
+        system_id = make_string_without_spaces()
+        node = Node(system_id)
+        interfaces = [
+            {
+                "system_id": system_id,
+                "id": random.randint(0, 100),
+                "name": make_string_without_spaces(),
+                "type": InterfaceType.PHYSICAL.value,
+            }
+            for _ in range(3)
+        ]
+        Interfaces._handler.read.return_value = interfaces
+        interfaces = Interfaces.read(node)
+        self.assertThat(len(interfaces), Equals(3))
+        Interfaces._handler.read.assert_called_once_with(system_id=system_id)
+
+    def test__create_bad_node_type(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            TypeError, Interfaces.create, random.randint(0, 100))
+        self.assertEquals("node must be a Node or str, not int", str(error))
+
+    def test__create_bad_vlan_type(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            TypeError, Interfaces.create,
+            make_string_without_spaces(), vlan=make_string_without_spaces())
+        self.assertEquals("vlan must be a Vlan or int, not str", str(error))
+
+    def test__create_bad_interface_type_type(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            TypeError, Interfaces.create,
+            make_string_without_spaces(),
+            interface_type=make_string_without_spaces())
+        self.assertEquals(
+            "interface_type must be an InterfaceType, not str", str(error))
+
+    def test__create_physical_requires_mac_address(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces())
+        self.assertEquals(
+            "mac_address required for physical interface", str(error))
+
+    def test__create_physical_with_all_values(self):
+        origin = make_origin()
+        Interfaces, Interface = origin.Interfaces, origin.Interface
+        system_id = make_string_without_spaces()
+        mac_address = "00:11:22:33:44:55"
+        name = make_string_without_spaces()
+        tags = [
+            make_string_without_spaces()
+            for _ in range(3)
+        ]
+        mtu = random.randint(1500, 3000)
+        vlan = random.randint(1, 20)
+        accept_ra = random.choice([True, False])
+        autoconf = random.choice([True, False])
+        interface_data = {
+            'system_id': system_id,
+            'id': random.randint(1, 20),
+            'type': InterfaceType.PHYSICAL.value,
+            'name': name,
+            'tags': tags,
+        }
+        Interfaces._handler.create_physical.return_value = interface_data
+        nic = Interfaces.create(
+            node=system_id, mac_address=mac_address, name=name,
+            tags=tags, mtu=mtu, vlan=vlan,
+            accept_ra=accept_ra, autoconf=autoconf)
+        self.assertThat(nic, IsInstance(Interface))
+        Interfaces._handler.create_physical.assert_called_once_with(
+            system_id=system_id, mac_address=mac_address, name=name,
+            tags=tags, mtu=mtu, vlan=vlan,
+            accept_ra=accept_ra, autoconf=autoconf)
+
+    def test__create_physical_with_objects(self):
+        origin = make_origin()
+        Interfaces, Interface = origin.Interfaces, origin.Interface
+        system_id = make_string_without_spaces()
+        node = origin.Node(system_id)
+        mac_address = "00:11:22:33:44:55"
+        name = make_string_without_spaces()
+        tags = [
+            make_string_without_spaces()
+            for _ in range(3)
+        ]
+        mtu = random.randint(1500, 3000)
+        vlan_id = random.randint(1, 20)
+        vlan = origin.Vlan({
+            'fabric_id': random.randint(1, 20),
+            'id': vlan_id,
+        })
+        accept_ra = random.choice([True, False])
+        autoconf = random.choice([True, False])
+        interface_data = {
+            'system_id': system_id,
+            'id': random.randint(1, 20),
+            'type': InterfaceType.PHYSICAL.value,
+            'name': name,
+            'tags': tags,
+        }
+        Interfaces._handler.create_physical.return_value = interface_data
+        nic = Interfaces.create(
+            node=node, mac_address=mac_address, name=name,
+            tags=tags, mtu=mtu, vlan=vlan,
+            accept_ra=accept_ra, autoconf=autoconf)
+        self.assertThat(nic, IsInstance(Interface))
+        Interfaces._handler.create_physical.assert_called_once_with(
+            system_id=system_id, mac_address=mac_address, name=name,
+            tags=tags, mtu=mtu, vlan=vlan_id,
+            accept_ra=accept_ra, autoconf=autoconf)
+
+    def test__create_bond_fails_with_parent(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.BOND,
+            name=make_string_without_spaces(),
+            parent=make_string_without_spaces())
+        self.assertEquals(
+            "use parents not parent for bond interface", str(error))
+
+    def test__create_bond_fails_parents_not_sequence(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            TypeError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.BOND,
+            name=make_string_without_spaces(),
+            parents=random.randint(1, 20))
+        self.assertEquals(
+            "parents must be a sequence, not int", str(error))
+
+    def test__create_bond_fails_parents_is_not_Interface_or_int(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            TypeError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.BOND,
+            name=make_string_without_spaces(),
+            parents=[make_string_without_spaces()])
+        self.assertEquals(
+            "parent[0] must be an Interface or int, not str", str(error))
+
+    def test__create_bond_fails_name_missing(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.BOND,
+            parents=[random.randint(1, 20)])
+        self.assertEquals(
+            "name is required for bond interface", str(error))
+
+    def test__create_bond_with_all_values(self):
+        origin = make_origin()
+        Interfaces, Interface = origin.Interfaces, origin.Interface
+        system_id = make_string_without_spaces()
+        mac_address = "00:11:22:33:44:55"
+        name = make_string_without_spaces()
+        tags = [
+            make_string_without_spaces()
+            for _ in range(3)
+        ]
+        mtu = random.randint(1500, 3000)
+        vlan = random.randint(1, 20)
+        accept_ra = random.choice([True, False])
+        autoconf = random.choice([True, False])
+        bond_mode = make_string_without_spaces()
+        bond_miimon = random.randint(1, 100)
+        bond_downdelay = random.randint(1, 10)
+        bond_updelay = random.randint(1, 10)
+        bond_lacp_rate = random.choice(['fast', 'slow'])
+        bond_xmit_hash_policy = make_string_without_spaces()
+        parents = [
+            random.randint(1, 10)
+            for _ in range(3)
+        ]
+        interface_data = {
+            'system_id': system_id,
+            'id': random.randint(1, 20),
+            'type': InterfaceType.BOND.value,
+            'name': name,
+            'tags': tags,
+        }
+        Interfaces._handler.create_bond.return_value = interface_data
+        nic = Interfaces.create(
+            node=system_id, interface_type=InterfaceType.BOND,
+            parents=parents, mac_address=mac_address, name=name,
+            tags=tags, mtu=mtu, vlan=vlan, accept_ra=accept_ra,
+            autoconf=autoconf, bond_mode=bond_mode, bond_miimon=bond_miimon,
+            bond_downdelay=bond_downdelay, bond_updelay=bond_updelay,
+            bond_lacp_rate=bond_lacp_rate,
+            bond_xmit_hash_policy=bond_xmit_hash_policy)
+        self.assertThat(nic, IsInstance(Interface))
+        Interfaces._handler.create_bond.assert_called_once_with(
+            system_id=system_id,
+            parents=parents, mac_address=mac_address, name=name,
+            tags=tags, mtu=mtu, vlan=vlan, accept_ra=accept_ra,
+            autoconf=autoconf, bond_mode=bond_mode, bond_miimon=bond_miimon,
+            bond_downdelay=bond_downdelay, bond_updelay=bond_updelay,
+            bond_lacp_rate=bond_lacp_rate,
+            bond_xmit_hash_policy=bond_xmit_hash_policy)
+
+    def test__create_bond_with_objects(self):
+        origin = make_origin()
+        Interfaces, Interface = origin.Interfaces, origin.Interface
+        system_id = make_string_without_spaces()
+        node = origin.Node(system_id)
+        mac_address = "00:11:22:33:44:55"
+        name = make_string_without_spaces()
+        tags = [
+            make_string_without_spaces()
+            for _ in range(3)
+        ]
+        mtu = random.randint(1500, 3000)
+        vlan_id = random.randint(1, 10)
+        vlan = origin.Vlan({
+            'fabric_id': random.randint(1, 20),
+            'id': vlan_id,
+        })
+        accept_ra = random.choice([True, False])
+        autoconf = random.choice([True, False])
+        bond_mode = make_string_without_spaces()
+        bond_miimon = random.randint(1, 100)
+        bond_downdelay = random.randint(1, 10)
+        bond_updelay = random.randint(1, 10)
+        bond_lacp_rate = random.choice(['fast', 'slow'])
+        bond_xmit_hash_policy = make_string_without_spaces()
+        parents = [
+            random.randint(1, 10)
+            for _ in range(3)
+        ]
+        parent_objs = [
+            Interface((system_id, parent))
+            for parent in parents
+        ]
+        interface_data = {
+            'system_id': system_id,
+            'id': random.randint(1, 20),
+            'type': InterfaceType.BOND.value,
+            'name': name,
+            'tags': tags,
+        }
+        Interfaces._handler.create_bond.return_value = interface_data
+        nic = Interfaces.create(
+            node=node, interface_type=InterfaceType.BOND,
+            parents=parent_objs, mac_address=mac_address, name=name,
+            tags=tags, mtu=mtu, vlan=vlan, accept_ra=accept_ra,
+            autoconf=autoconf, bond_mode=bond_mode, bond_miimon=bond_miimon,
+            bond_downdelay=bond_downdelay, bond_updelay=bond_updelay,
+            bond_lacp_rate=bond_lacp_rate,
+            bond_xmit_hash_policy=bond_xmit_hash_policy)
+        self.assertThat(nic, IsInstance(Interface))
+        Interfaces._handler.create_bond.assert_called_once_with(
+            system_id=system_id,
+            parents=parents, mac_address=mac_address, name=name,
+            tags=tags, mtu=mtu, vlan=vlan_id, accept_ra=accept_ra,
+            autoconf=autoconf, bond_mode=bond_mode, bond_miimon=bond_miimon,
+            bond_downdelay=bond_downdelay, bond_updelay=bond_updelay,
+            bond_lacp_rate=bond_lacp_rate,
+            bond_xmit_hash_policy=bond_xmit_hash_policy)
+
+    def test__create_vlan_fails_with_parents(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.VLAN,
+            parents=[make_string_without_spaces()])
+        self.assertEquals(
+            "use parent not parents for VLAN interface", str(error))
+
+    def test__create_vlan_fails_without_parent(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.VLAN)
+        self.assertEquals(
+            "parent is required for VLAN interface", str(error))
+
+    def test__create_vlan_fails_parent_wrong_type(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            TypeError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.VLAN,
+            parent=make_string_without_spaces())
+        self.assertEquals(
+            "parent must be an Interface or int, not str", str(error))
+
+    def test__create_vlan_fails_without_vlan(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.VLAN,
+            parent=random.randint(1, 10))
+        self.assertEquals(
+            "vlan is required for VLAN interface", str(error))
+
+    def test__create_vlan_with_all_values(self):
+        origin = make_origin()
+        Interfaces, Interface = origin.Interfaces, origin.Interface
+        system_id = make_string_without_spaces()
+        tags = [
+            make_string_without_spaces()
+            for _ in range(3)
+        ]
+        mtu = random.randint(1500, 3000)
+        vlan = random.randint(1, 20)
+        accept_ra = random.choice([True, False])
+        autoconf = random.choice([True, False])
+        parent = random.randint(1, 10)
+        interface_data = {
+            'system_id': system_id,
+            'id': random.randint(1, 20),
+            'type': InterfaceType.VLAN.value,
+            'tags': tags,
+        }
+        Interfaces._handler.create_vlan.return_value = interface_data
+        nic = Interfaces.create(
+            node=system_id, interface_type=InterfaceType.VLAN,
+            parent=parent, tags=tags, mtu=mtu, vlan=vlan, accept_ra=accept_ra,
+            autoconf=autoconf)
+        self.assertThat(nic, IsInstance(Interface))
+        Interfaces._handler.create_vlan.assert_called_once_with(
+            system_id=system_id, parent=parent,
+            tags=tags, mtu=mtu, vlan=vlan, accept_ra=accept_ra,
+            autoconf=autoconf)
+
+    def test__create_vlan_with_objects(self):
+        origin = make_origin()
+        Interfaces, Interface = origin.Interfaces, origin.Interface
+        system_id = make_string_without_spaces()
+        node = origin.Node(system_id)
+        tags = [
+            make_string_without_spaces()
+            for _ in range(3)
+        ]
+        mtu = random.randint(1500, 3000)
+        vlan_id = random.randint(1, 10)
+        vlan = origin.Vlan({
+            'fabric_id': random.randint(1, 20),
+            'id': vlan_id,
+        })
+        accept_ra = random.choice([True, False])
+        autoconf = random.choice([True, False])
+        parent_id = random.randint(1, 10)
+        parent_obj = Interface((system_id, parent_id))
+        interface_data = {
+            'system_id': system_id,
+            'id': random.randint(1, 20),
+            'type': InterfaceType.VLAN.value,
+            'tags': tags,
+        }
+        Interfaces._handler.create_vlan.return_value = interface_data
+        nic = Interfaces.create(
+            node=node, interface_type=InterfaceType.VLAN,
+            parent=parent_obj, tags=tags, mtu=mtu, vlan=vlan,
+            accept_ra=accept_ra, autoconf=autoconf)
+        self.assertThat(nic, IsInstance(Interface))
+        Interfaces._handler.create_vlan.assert_called_once_with(
+            system_id=system_id, parent=parent_id,
+            tags=tags, mtu=mtu, vlan=vlan_id, accept_ra=accept_ra,
+            autoconf=autoconf)
+
+    def test__create_bridge_fails_with_parents(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.BRIDGE,
+            parents=[make_string_without_spaces()])
+        self.assertEquals(
+            "use parent not parents for bridge interface", str(error))
+
+    def test__create_bridge_fails_without_parent(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.BRIDGE)
+        self.assertEquals(
+            "parent is required for bridge interface", str(error))
+
+    def test__create_bridge_fails_parent_wrong_type(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            TypeError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.BRIDGE,
+            parent=make_string_without_spaces())
+        self.assertEquals(
+            "parent must be an Interface or int, not str", str(error))
+
+    def test__create_bridge_fails_missing_name(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.BRIDGE,
+            parent=random.randint(1, 10))
+        self.assertEquals(
+            "name is required for bridge interface", str(error))
+
+    def test__create_bridge_with_all_values(self):
+        origin = make_origin()
+        Interfaces, Interface = origin.Interfaces, origin.Interface
+        system_id = make_string_without_spaces()
+        name = make_string_without_spaces()
+        mac_address = "00:11:22:33:44:55"
+        tags = [
+            make_string_without_spaces()
+            for _ in range(3)
+        ]
+        mtu = random.randint(1500, 3000)
+        vlan = random.randint(1, 20)
+        accept_ra = random.choice([True, False])
+        autoconf = random.choice([True, False])
+        parent = random.randint(1, 10)
+        bridge_stp = random.choice([True, False])
+        bridge_fd = random.randint(1, 10)
+        interface_data = {
+            'system_id': system_id,
+            'id': random.randint(1, 20),
+            'type': InterfaceType.BRIDGE.value,
+            'name': name,
+            'tags': tags,
+        }
+        Interfaces._handler.create_bridge.return_value = interface_data
+        nic = Interfaces.create(
+            node=system_id, interface_type=InterfaceType.BRIDGE,
+            parent=parent, name=name, tags=tags, mtu=mtu, vlan=vlan,
+            accept_ra=accept_ra, autoconf=autoconf, mac_address=mac_address,
+            bridge_stp=bridge_stp, bridge_fd=bridge_fd)
+        self.assertThat(nic, IsInstance(Interface))
+        Interfaces._handler.create_bridge.assert_called_once_with(
+            system_id=system_id, parent=parent, name=name,
+            tags=tags, mtu=mtu, vlan=vlan, accept_ra=accept_ra,
+            autoconf=autoconf, mac_address=mac_address,
+            bridge_stp=bridge_stp, bridge_fd=bridge_fd)
+
+    def test__create_bridge_with_objects(self):
+        origin = make_origin()
+        Interfaces, Interface = origin.Interfaces, origin.Interface
+        system_id = make_string_without_spaces()
+        node = origin.Node(system_id)
+        name = make_string_without_spaces()
+        mac_address = "00:11:22:33:44:55"
+        tags = [
+            make_string_without_spaces()
+            for _ in range(3)
+        ]
+        mtu = random.randint(1500, 3000)
+        vlan_id = random.randint(1, 10)
+        vlan = origin.Vlan({
+            'fabric_id': random.randint(1, 20),
+            'id': vlan_id,
+        })
+        accept_ra = random.choice([True, False])
+        autoconf = random.choice([True, False])
+        parent_id = random.randint(1, 10)
+        parent_obj = Interface((system_id, parent_id))
+        bridge_stp = random.choice([True, False])
+        bridge_fd = random.randint(1, 10)
+        interface_data = {
+            'system_id': system_id,
+            'id': random.randint(1, 20),
+            'type': InterfaceType.VLAN.value,
+            'name': name,
+            'tags': tags,
+        }
+        Interfaces._handler.create_bridge.return_value = interface_data
+        nic = Interfaces.create(
+            node=node, interface_type=InterfaceType.BRIDGE,
+            parent=parent_obj, name=name, tags=tags, mtu=mtu, vlan=vlan,
+            accept_ra=accept_ra, autoconf=autoconf, mac_address=mac_address,
+            bridge_stp=bridge_stp, bridge_fd=bridge_fd)
+        self.assertThat(nic, IsInstance(Interface))
+        Interfaces._handler.create_bridge.assert_called_once_with(
+            system_id=system_id, parent=parent_id, name=name,
+            tags=tags, mtu=mtu, vlan=vlan_id, accept_ra=accept_ra,
+            autoconf=autoconf, mac_address=mac_address,
+            bridge_stp=bridge_stp, bridge_fd=bridge_fd)
+
+    def test__create_unknown_fails(self):
+        Interfaces = make_origin().Interfaces
+        error = self.assertRaises(
+            ValueError, Interfaces.create,
+            make_string_without_spaces(), InterfaceType.UNKNOWN)
+        self.assertEquals(
+            "cannot create an interface of type: %s" % InterfaceType.UNKNOWN,
+            str(error))
+
+
+class TestInterface(TestCase):
+
+    def test__interface_read_system_id(self):
+        Interface = make_origin().Interface
+        system_id = make_string_without_spaces()
+        interface = {
+            "system_id": system_id,
+            "id": random.randint(0, 100),
+            "name": make_string_without_spaces(),
+            "type": InterfaceType.PHYSICAL.value,
+        }
+        Interface._handler.read.return_value = interface
+        self.assertThat(
+            Interface.read(node=system_id, id=interface["id"]),
+            Equals(Interface(interface)))
+        Interface._handler.read.assert_called_once_with(
+            system_id=system_id, id=interface["id"])
+
+    def test__interface_read_Node(self):
+        origin = make_origin()
+        Interface = origin.Interface
+        system_id = make_string_without_spaces()
+        interface = {
+            "system_id": system_id,
+            "id": random.randint(0, 100),
+            "name": make_string_without_spaces(),
+            "type": InterfaceType.PHYSICAL.value,
+        }
+        Interface._handler.read.return_value = interface
+        self.assertThat(
+            Interface.read(node=origin.Node(system_id), id=interface["id"]),
+            Equals(Interface(interface)))
+        Interface._handler.read.assert_called_once_with(
+            system_id=system_id, id=interface["id"])
+
+    def test__interface_read_TypeError(self):
+        Interface = make_origin().Interface
+        error = self.assertRaises(
+            TypeError, Interface.read,
+            random.randint(0, 100), random.randint(0, 100))
+        self.assertEquals("node must be a Node or str, not int", str(error))
+
+    def test__interface_delete(self):
+        Interface = make_origin().Interface
+        system_id = make_string_without_spaces()
+        interface_data = {
+            "system_id": system_id,
+            "id": random.randint(0, 100),
+            "name": make_string_without_spaces(),
+            "type": InterfaceType.PHYSICAL.value,
+        }
+        interface = Interface(interface_data)
+        interface.delete()
+        Interface._handler.delete.assert_called_once_with(
+            system_id=system_id, id=interface_data['id'])

--- a/maas/client/viscera/tests/test_interfaces.py
+++ b/maas/client/viscera/tests/test_interfaces.py
@@ -193,7 +193,7 @@ class TestInterfaces(TestCase):
         self.assertEquals(
             "use parents not parent for bond interface", str(error))
 
-    def test__create_bond_fails_parents_not_sequence(self):
+    def test__create_bond_fails_parents_not_iterable(self):
         Interfaces = make_origin().Interfaces
         error = self.assertRaises(
             TypeError, Interfaces.create,
@@ -201,7 +201,7 @@ class TestInterfaces(TestCase):
             name=make_string_without_spaces(),
             parents=random.randint(1, 20))
         self.assertEquals(
-            "parents must be a sequence, not int", str(error))
+            "parents must be a iterable, not int", str(error))
 
     def test__create_bond_fails_parents_is_not_Interface_or_int(self):
         Interfaces = make_origin().Interfaces


### PR DESCRIPTION
This adds the ability to create all interface types on any node.

```
machine = client.machines.list()[0]
nic1 = machine.interfaces.create(mac_address="00:11:22:33:aa:bb")
nic2 = machine.interfaces.create(mac_address="00:11:22:33:aa:cc")
bond = machine.interfaces.create(InterfaceType.BOND, name="bond0", parents=[nic1, nic2])
default_vlan = client.fabrics.get_default().vlans.get_default()
bond.vlan = default_vlan
bond.save()
vlan_10 = client.fabrics.get_default().vlans.create(10)
bond_vlan = machine.interfaces.create(InterfaceType.VLAN, parent=bond, vlan=vlan_10)
bridge_on_vlan = machine.interfaces.create(InterfaceType.BRIDGE, name="br0", parent=bond_vlan)
```

Adds the ability to delete an interface.

```
bridge_on_vlan.delete()
```

Adds ability to update tags and params on an interface.

```
bond0.tags.append("bond")
bond0.params['mtu'] = 3000
bond0.save()
```