### PR TITLE
Add ability to view, create, and delete interface links.

### DIFF
--- a/doc/client/interfaces.md
+++ b/doc/client/interfaces.md
@@ -47,6 +47,39 @@ False
   ]>
 ```
 
+## Get interface by name
+
+The ``interfaces`` property on ``Node`` gives you access to all interfaces on
+the node. Sometimes you want to access the interface objects by name.
+``by_name`` and ``get_by_name`` are helpers on ``Interfaces`` that help.
+
+```pycon
+>>> machine.interfaces.by_name
+{'bond0': <Interface mac_address='52:54:00:b4:7e:8c'
+    name='bond0' type=<InterfaceType.BOND: 'bond'>>,
+ 'ens3': <Interface mac_address='52:54:00:b4:7e:8c'
+     name='ens3' type=<InterfaceType.PHYSICAL: 'physical'>>,
+ 'ens8': <Interface mac_address='52:54:00:11:f3:d2'
+    name='ens8' type=<InterfaceType.PHYSICAL: 'physical'>>}
+>>> bond = machine.interfaces.get_by_name('bond0')
+>>> bond
+<Interface mac_address='52:54:00:b4:7e:8c'
+    name='bond0' type=<InterfaceType.BOND: 'bond'>>
+```
+
+## Read IP configuration
+
+Every ``Interface`` has a ``links`` property that provides all the IP
+information on how the interface is configured.
+
+```pycon
+>>> bond.links
+<InterfaceLinks.Managed#Interface length=1 items=[
+  <InterfaceLink ip_address=None mode=<LinkMode.AUTO: 'auto'>
+    subnet=<Subnet cidr='192.168.122.0/24' name='192.168.122.0/24'
+      vlan=<Vlan name='untagged' vid=0>>>]>
+```
+
 ## Create physical
 
 Creation of interfaces is done directly on the ``interfaces`` property of a
@@ -132,6 +165,34 @@ calling ``save`` is all that is required.
 >>> new_bond.name = 'my-bond'
 >>> new_bond.params['bond_mode'] = 'active-backup'
 >>> new_bond.save()
+```
+
+## Change IP configuration
+
+To adjust the IP configuration on a specific interface ``create`` on the
+``links`` property and ``delete`` on the ``InterfaceLink`` can be used.
+
+```pycon
+>>> new_bond.links.create(LinkMode.AUTO, subnet=subnet)
+<InterfaceLink ip_address=None mode=<LinkMode.AUTO: 'auto'>
+  subnet=<Subnet cidr='192.168.122.0/24' name='192.168.122.0/24'
+    vlan=<Vlan name='untagged' vid=0>>>
+>>> new_bond.links[-1].delete()
+>>> new_bond.links.create(
+...     LinkMode.STATIC, subnet=subnet, ip_address='192.168.122.1')
+<InterfaceLink ip_address='192.168.122.10' mode=<LinkMode.STATIC: 'static'>
+  subnet=<Subnet cidr='192.168.122.0/24' name='192.168.122.0/24'
+    vlan=<Vlan name='untagged' vid=0>>>
+>>> new_bond.links[-1].delete()
+```
+
+## Disconnect interface
+
+To completely mark an interface as disconnected and remove all configuration
+the ``disconnect`` call makes this easy.
+
+```
+>>> new_bond.disconnect()
 ```
 
 ## Delete interface

--- a/maas/client/bones/__init__.py
+++ b/maas/client/bones/__init__.py
@@ -286,11 +286,19 @@ class ActionAPI:
         Whatever remains is assumed to be data to be passed to ``call()`` as
         keyword arguments.
 
+        All keys in ``params`` that are prefixed with '_' are remapped without
+        the '_' prefix into the ``call()``. This is used when the ``params``
+        and data passed to the call have the same key.
+
         :raise KeyError: If not all required arguments are provided.
 
         See `CallAPI.call()` for return information and exceptions.
         """
+        data = dict(data)
         params = {name: data.pop(name) for name in self.handler.params}
+        for key, value in data.items():
+            if key.startswith('_'):
+                data[key[1:]] = data.pop(key)
         response = await self.bind(**params).call(**data)
         return response.data
 

--- a/maas/client/enum.py
+++ b/maas/client/enum.py
@@ -117,3 +117,14 @@ class InterfaceType(enum.Enum):
     VLAN = 'vlan'
     #: Interface not linked to a node.
     UNKNOWN = 'unknown'
+
+
+class LinkMode(enum.Enum):
+    #: IP is auto assigned by MAAS.
+    AUTO = 'auto'
+    #: IP is assigned by a DHCP server.
+    DHCP = 'dhcp'
+    #: IP is statically assigned.
+    STATIC = 'static'
+    #: Connected to subnet with no IP address.
+    LINK_UP = 'link_up'

--- a/maas/client/viscera/interfaces.py
+++ b/maas/client/viscera/interfaces.py
@@ -5,6 +5,7 @@ __all__ = [
     "Interfaces",
 ]
 
+import copy
 from typing import Iterable, Union
 
 from . import (
@@ -18,8 +19,12 @@ from . import (
     to,
 )
 from .nodes import Node
+from .subnets import Subnet
 from .vlans import Vlan
-from ..enum import InterfaceType
+from ..enum import (
+    InterfaceType,
+    LinkMode,
+)
 from ..utils.diff import calculate_dict_diff
 
 
@@ -110,9 +115,10 @@ class Interface(Object, metaclass=InterfaceTypeMeta):
         map_func=map_nic_name_to_dict)
     vlan = ObjectFieldRelated(
         "vlan", "Vlan", reverse=None, use_data_setter=True)
-
-    # links
-    # discovered
+    links = ObjectFieldRelatedSet(
+        "links", "InterfaceLinks", reverse="interface")
+    discovered = ObjectFieldRelatedSet(
+        "discovered", "InterfaceDiscoveredLinks", reverse=None)
 
     def __repr__(self):
         return super(Interface, self).__repr__(
@@ -142,6 +148,144 @@ class Interface(Object, metaclass=InterfaceTypeMeta):
         """Delete this interface."""
         await self._handler.delete(
             system_id=self.node.system_id, id=self.id)
+
+    async def disconnect(self):
+        """Disconnect this interface."""
+        self._data = await self._handler.disconnect(
+            system_id=self.node.system_id, id=self.id)
+
+
+class InterfaceDiscoveredLink(Object):
+    """Discovered link information on an `Interface`."""
+
+    ip_address = ObjectField.Checked(
+        "ip_address", check(str), readonly=True, default=None)
+    subnet = ObjectFieldRelated(
+        "subnet", "Subnet", readonly=True, default=None)
+
+
+class InterfaceDiscoveredLinks(ObjectSet):
+    """A set of discovered links on an `Interface`."""
+
+
+class InterfaceLink(Object):
+    """A link on an `Interface`."""
+
+    id = ObjectField.Checked("id", check(int), readonly=True)
+    mode = ObjectField.Checked("mode", to(LinkMode), readonly=True)
+    subnet = ObjectFieldRelated(
+        "subnet", "Subnet", readonly=True, default=None)
+    ip_address = ObjectField.Checked(
+        "ip_address", check(str), readonly=True, default=None)
+
+    def __repr__(self):
+        return super(InterfaceLink, self).__repr__(
+            fields={"mode", "ip_address", "subnet"})
+
+    async def delete(self):
+        """Delete this interface link."""
+        interface = self._data['interface']
+        data = await interface._handler.unlink_subnet(
+            system_id=interface.node.system_id, id=interface.id, _id=self.id)
+        interface._data['links'] = list(data['links'])
+        interface._orig_data['links'] = copy.deepcopy(interface._data['links'])
+
+    async def set_as_default_gateway(self):
+        """Set this link as the default gateway for the node."""
+        interface = self._data['interface']
+        await interface._handler.set_default_gateway(
+            system_id=interface.node.system_id, id=interface.id,
+            link_id=self.id)
+
+
+class InterfaceLinksType(ObjectType):
+    """Metaclass for `InterfaceLinks`."""
+
+    async def create(
+            cls, interface: Interface, mode: LinkMode,
+            subnet: Union[Subnet, int]=None, ip_address: str=None,
+            force: bool=False, default_gateway: bool=False):
+        """
+        Create a link on `Interface` in MAAS.
+
+        :param interface: Interface to create the link on.
+        :type interface: `Interface`
+        :param mode: Mode of the link.
+        :type mode: `LinkMode`
+        :param subnet: The subnet to create the link on (optional).
+        :type subnet: `Subnet` or `int`
+        :param ip_address: The IP address to assign to the link.
+        :type ip_address: `str`
+        :param force: If True, allows `LinkMode.LINK_UP` to be created even if
+            other links already exist. Also allows the selection of any
+            subnet no matter the VLAN the subnet belongs to. Using this option
+            will cause all other interface links to be deleted (optional).
+        :type force: `bool`
+        :param default_gateway: If True, sets the gateway IP address for the
+            subnet as the default gateway for the node this interface belongs
+            to. Option can only be used with the `LinkMode.AUTO` and
+            `LinkMode.STATIC` modes.
+        :type default_gateway: `bool`
+
+        :returns: The created InterfaceLink.
+        :rtype: `InterfaceLink`
+        """
+        # The API doesn't return just the link it returns the whole interface.
+        # Store the link ids before the save to find the addition at the end.
+        link_ids = {
+            link.id
+            for link in interface.links
+        }
+        if not isinstance(interface, Interface):
+            raise TypeError(
+                "interface must be an Interface, not %s"
+                % type(interface).__name__)
+        if not isinstance(mode, LinkMode):
+            raise TypeError(
+                "mode must be a LinkMode, not %s"
+                % type(interface).__name__)
+        if subnet is not None:
+            if isinstance(subnet, Subnet):
+                subnet = subnet.id
+            elif isinstance(subnet, int):
+                pass
+            else:
+                raise TypeError(
+                    "subnet must be a Subnet or int, not %s"
+                    % type(interface).__name__)
+        if mode in [LinkMode.AUTO, LinkMode.STATIC]:
+            if not subnet:
+                raise ValueError('subnet is required for %s' % mode)
+        if default_gateway and mode not in [LinkMode.AUTO, LinkMode.STATIC]:
+            raise ValueError('cannot set as default_gateway for %s' % mode)
+        params = {
+            'system_id': interface.node.system_id,
+            'id': interface.id,
+            'mode': mode.value,
+            'force': force,
+            'default_gateway': default_gateway,
+        }
+        if subnet is not None:
+            params['subnet'] = subnet
+        if ip_address is not None:
+            params['ip_address'] = ip_address
+        data = await interface._handler.link_subnet(**params)
+        # Update the links on the interface, except for the newly created link
+        # the `ManagedCreate` wrapper will add that to the interfaces link data
+        # automatically.
+        new_links = {
+            link['id']: link
+            for link in data['links']
+        }
+        links_diff = list(set(new_links.keys()) - link_ids)
+        new_link = new_links.pop(links_diff[0])
+        interface._data['links'] = list(new_links.values())
+        interface._orig_data['links'] = copy.deepcopy(interface._data['links'])
+        return cls._object(new_link)
+
+
+class InterfaceLinks(ObjectSet, metaclass=InterfaceLinksType):
+    """A set of links on an `Interface`."""
 
 
 class InterfacesType(ObjectType):
@@ -348,3 +492,15 @@ class InterfacesType(ObjectType):
 
 class Interfaces(ObjectSet, metaclass=InterfacesType):
     """The set of interfaces on a machine."""
+
+    @property
+    def by_name(self):
+        """Return mapping of name of interface to interface object."""
+        return {
+            interface.name: interface
+            for interface in self
+        }
+
+    def get_by_name(self, name):
+        """Return an interface by its name."""
+        return self.by_name[name]

--- a/maas/client/viscera/interfaces.py
+++ b/maas/client/viscera/interfaces.py
@@ -230,12 +230,6 @@ class InterfaceLinksType(ObjectType):
         :returns: The created InterfaceLink.
         :rtype: `InterfaceLink`
         """
-        # The API doesn't return just the link it returns the whole interface.
-        # Store the link ids before the save to find the addition at the end.
-        link_ids = {
-            link.id
-            for link in interface.links
-        }
         if not isinstance(interface, Interface):
             raise TypeError(
                 "interface must be an Interface, not %s"
@@ -243,7 +237,7 @@ class InterfaceLinksType(ObjectType):
         if not isinstance(mode, LinkMode):
             raise TypeError(
                 "mode must be a LinkMode, not %s"
-                % type(interface).__name__)
+                % type(mode).__name__)
         if subnet is not None:
             if isinstance(subnet, Subnet):
                 subnet = subnet.id
@@ -252,7 +246,7 @@ class InterfaceLinksType(ObjectType):
             else:
                 raise TypeError(
                     "subnet must be a Subnet or int, not %s"
-                    % type(interface).__name__)
+                    % type(subnet).__name__)
         if mode in [LinkMode.AUTO, LinkMode.STATIC]:
             if not subnet:
                 raise ValueError('subnet is required for %s' % mode)
@@ -269,6 +263,12 @@ class InterfaceLinksType(ObjectType):
             params['subnet'] = subnet
         if ip_address is not None:
             params['ip_address'] = ip_address
+        # The API doesn't return just the link it returns the whole interface.
+        # Store the link ids before the save to find the addition at the end.
+        link_ids = {
+            link.id
+            for link in interface.links
+        }
         data = await interface._handler.link_subnet(**params)
         # Update the links on the interface, except for the newly created link
         # the `ManagedCreate` wrapper will add that to the interfaces link data


### PR DESCRIPTION
Includes the ability to view, update, and delete IP link information on interfaces. Also includes viewing the discovered IP information from commissioning on the interface.

Adds helpers for `Interfaces` with `by_name` property and `get_by_name` method.