### PR TITLE
Fix unit tests so updated link ids do not collide.

### DIFF
--- a/maas/client/viscera/interfaces.py
+++ b/maas/client/viscera/interfaces.py
@@ -248,7 +248,7 @@ class InterfaceLinksType(ObjectType):
                     "subnet must be a Subnet or int, not %s"
                     % type(subnet).__name__)
         if mode in [LinkMode.AUTO, LinkMode.STATIC]:
-            if not subnet:
+            if subnet is None:
                 raise ValueError('subnet is required for %s' % mode)
         if default_gateway and mode not in [LinkMode.AUTO, LinkMode.STATIC]:
             raise ValueError('cannot set as default_gateway for %s' % mode)

--- a/maas/client/viscera/tests/test_interfaces.py
+++ b/maas/client/viscera/tests/test_interfaces.py
@@ -945,7 +945,7 @@ class TestInterface(TestCase):
         }
         interface = Interface(interface_data)
         updated_data = dict(interface_data)
-        link_id = random.randint(0, 100)
+        link_id = random.randint(100, 200)
         subnet_id = random.randint(0, 100)
         updated_data['links'] = [
             {
@@ -990,7 +990,7 @@ class TestInterface(TestCase):
         }
         interface = Interface(interface_data)
         updated_data = dict(interface_data)
-        link_id = random.randint(0, 100)
+        link_id = random.randint(100, 200)
         subnet_id = random.randint(0, 100)
         updated_data['links'] = [
             {
@@ -1039,7 +1039,7 @@ class TestInterface(TestCase):
         }
         interface = Interface(interface_data)
         updated_data = dict(interface_data)
-        link_id = random.randint(0, 100)
+        link_id = random.randint(100, 200)
         subnet_id = random.randint(0, 100)
         updated_data['links'] = [
             {

--- a/maas/client/viscera/tests/test_interfaces.py
+++ b/maas/client/viscera/tests/test_interfaces.py
@@ -946,7 +946,7 @@ class TestInterface(TestCase):
         interface = Interface(interface_data)
         updated_data = dict(interface_data)
         link_id = random.randint(100, 200)
-        subnet_id = random.randint(0, 100)
+        subnet_id = random.randint(1, 100)
         updated_data['links'] = [
             {
                 'id': link_id,
@@ -991,7 +991,7 @@ class TestInterface(TestCase):
         interface = Interface(interface_data)
         updated_data = dict(interface_data)
         link_id = random.randint(100, 200)
-        subnet_id = random.randint(0, 100)
+        subnet_id = random.randint(1, 100)
         updated_data['links'] = [
             {
                 'id': link_id,
@@ -1040,7 +1040,7 @@ class TestInterface(TestCase):
         interface = Interface(interface_data)
         updated_data = dict(interface_data)
         link_id = random.randint(100, 200)
-        subnet_id = random.randint(0, 100)
+        subnet_id = random.randint(1, 100)
         updated_data['links'] = [
             {
                 'id': link_id,
@@ -1078,7 +1078,7 @@ class TestInterface(TestCase):
         interface = Interface(interface_data)
         updated_data = dict(interface_data)
         link_id = random.randint(0, 100)
-        subnet_id = random.randint(0, 100)
+        subnet_id = random.randint(1, 100)
         updated_data['links'] = [
             {
                 'id': link_id,
@@ -1107,7 +1107,7 @@ class TestInterface(TestCase):
         Interface, Subnet = origin.Interface, origin.Subnet
         system_id = make_string_without_spaces()
         link_id = random.randint(0, 100)
-        subnet_id = random.randint(0, 100)
+        subnet_id = random.randint(1, 100)
         interface_data = {
             "system_id": system_id,
             "id": random.randint(0, 100),
@@ -1126,7 +1126,7 @@ class TestInterface(TestCase):
         interface = Interface(interface_data)
         updated_data = dict(interface_data)
         new_link_id = random.randint(0, 100)
-        new_subnet_id = random.randint(0, 100)
+        new_subnet_id = random.randint(1, 100)
         updated_data['links'] = [
             {
                 'id': new_link_id,
@@ -1152,7 +1152,7 @@ class TestInterface(TestCase):
         Interface = origin.Interface
         system_id = make_string_without_spaces()
         link_id = random.randint(0, 100)
-        subnet_id = random.randint(0, 100)
+        subnet_id = random.randint(1, 100)
         interface_data = {
             "system_id": system_id,
             "id": random.randint(0, 100),


### PR DESCRIPTION
MAAS always increments the link ID, so this will not happen in the real world. Only the unit tests has this issue when the 2 random ids happen to be the same number.