### PR TITLE
Refactor list commands to use the new format. Use the pager on all table outputs and help outputs.

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -2,14 +2,14 @@
 
 _python-libmaas_ provides:
 
+* A command-line tool for working with MAAS servers.
+
 * A rich and stable Python client library for interacting with MAAS 2.0+
   servers. This can be used in a synchronous/blocking mode, or an
   asynchronous/non-blocking mode based on [asyncio][].
 
 * A lower-level Python client library, auto-generated to match the MAAS
   server it's interacting with.
-
-* A command-line tool for working with MAAS servers.
 
 For MAAS _server_ documentation, visit
 [docs.ubuntu.com](https://docs.ubuntu.com/maas/).
@@ -58,19 +58,76 @@ your shell's ``PATH`` so you can invoke it as ``maas``.
 
 ## Command-line
 
+Best place to start with the CLI is the help menu.
+
 ```console
-$ bin/maas profiles login --help
-$ bin/maas profiles login exmpl \
->   http://example.com:5240/MAAS/ my_username
-Password: …
-$ bin/maas list
-┌───┬────────────┬───────────┬───────┬────────┬────────┬─────────┐
-│   │ Hostname   │ System ID │ #CPUs │ RAM    │ Status │ Power   │
-├───┼────────────┼───────────┼───────┼────────┼────────┼─────────┤
-│ m │ botswana   │ pncys4    │ 4     │ 8.0 GB │ Ready  │ Off     │
-│ c │ namibia    │ xfaxgw    │ 4     │ 8.0 GB │ —      │ Error   │
-│ C │ madagascar │ 4y3h7n    │ 4     │ 8.0 GB │ —      │ Unknown │
-└───┴────────────┴───────────┴───────┴────────┴────────┴─────────┘
+$ bin/maas help
+$ bin/maas help commands
+```
+
+Once your have familiarized yourself with the available commands you will
+want to login to your MAAS. You can either pass arguments to login or it
+will ask your for the needed information to login.
+
+```console
+$ bin/maas login
+```
+
+The CLI supports multiple profiles with ``login``. Use ``profiles`` and
+``switch`` to view and change between profiles.
+
+```console
+$ bin/maas profiles
+┌─────────┬─────────────────────────────────────┬────────┐
+│ Profile │ URL                                 │ Active │
+├─────────┼─────────────────────────────────────┼────────┤
+│ admin   │ http://localhost:5240/MAAS/api/2.0/ │ ✓      │
+│ other   │ http://localhost:5240/MAAS/api/2.0/ │        │
+└─────────┴─────────────────────────────────────┴────────┘
+$ bin/maas switch other
+$ bin/maas profiles
+┌─────────┬─────────────────────────────────────┬────────┐
+│ Profile │ URL                                 │ Active │
+├─────────┼─────────────────────────────────────┼────────┤
+│ admin   │ http://localhost:5240/MAAS/api/2.0/ │        │
+│ other   │ http://localhost:5240/MAAS/api/2.0/ │ ✓      │
+└─────────┴─────────────────────────────────────┴────────┘
+```
+
+The ``nodes``, ``machines``, ``devices``, and ``controllers`` provide access
+to either all nodes with ``nodes`` or specific node types with ``machines``,
+``devices``, and ``controllers``.
+
+```console
+$ bin/maas nodes
+┌────────────────────┬───────────────┐
+│ Hostname           │ Type          │
+├────────────────────┼───────────────┤
+│ another            │ Device        │
+│ blake-ubnt-desktop │ Regiond+rackd │
+│ testing            │ Device        │
+│ win2016            │ Machine       │
+└────────────────────┴───────────────┘
+$ bin/maas machines
+┌──────────┬───────┬────────┬───────┬───────┬────────┐
+│ Hostname │ Power │ Status │ Arch  │ #CPUs │ RAM    │
+├──────────┼───────┼────────┼───────┼───────┼────────┤
+│ win2016  │ Off   │ Broken │ amd64 │ 4     │ 8.0 GB │
+└──────────┴───────┴────────┴───────┴───────┴────────┘
+$ bin/maas devices
+┌──────────┬───────────────┐
+│ Hostname │ IP addresses  │
+├──────────┼───────────────┤
+│ another  │ 192.168.1.223 │
+│ testing  │ 192.168.1.150 │
+│          │ 192.168.1.143 │
+└──────────┴───────────────┘
+$ bin/maas controllers
+┌────────────────────┬───────────────┬───────┬───────┬─────────┐
+│ Hostname           │ Type          │ Arch  │ #CPUs │ RAM     │
+├────────────────────┼───────────────┼───────┼───────┼─────────┤
+│ blake-ubnt-desktop │ Regiond+rackd │ amd64 │ 8     │ 24.0 GB │
+└────────────────────┴───────────────┴───────┴───────┴─────────┘
 ```
 
 Tab-completion in ``bash`` and ``tcsh`` is supported too. For example,
@@ -79,7 +136,7 @@ in ``bash``:
 ```console
 $ source <(bin/register-python-argcomplete --shell=bash bin/maas)
 $ bin/maas <tab>
-allocate  launch  list  list-files  list-tags  ...
+allocate  files  login  nodes  shell  ...
 ```
 
 

--- a/maas/client/flesh/controllers.py
+++ b/maas/client/flesh/controllers.py
@@ -1,0 +1,34 @@
+"""Commands for controllers."""
+
+__all__ = [
+    "register",
+]
+
+import asyncio
+from itertools import chain
+
+from . import (
+    OriginPagedTableCommand,
+    tables,
+)
+from ..utils.async import asynchronous
+
+
+class cmd_controllers(OriginPagedTableCommand):
+    """List all controllers."""
+
+    @asynchronous
+    async def execute(self, origin, options, target):
+        controller_sets = await asyncio.gather(
+            origin.RackControllers.read(), origin.RegionControllers.read())
+        controllers = {
+            controller.system_id: controller
+            for controller in chain.from_iterable(controller_sets)
+        }
+        table = tables.ControllersTable()
+        return table.render(target, controllers.values())
+
+
+def register(parser):
+    """Register commands with the given parser."""
+    cmd_controllers.register(parser)

--- a/maas/client/flesh/devices.py
+++ b/maas/client/flesh/devices.py
@@ -1,0 +1,23 @@
+"""Commands for devices."""
+
+__all__ = [
+    "register",
+]
+
+from . import (
+    OriginPagedTableCommand,
+    tables,
+)
+
+
+class cmd_devices(OriginPagedTableCommand):
+    """List all devices."""
+
+    def execute(self, origin, options, target):
+        table = tables.DevicesTable()
+        return table.render(target, origin.Devices.read())
+
+
+def register(parser):
+    """Register commands with the given parser."""
+    cmd_devices.register(parser)

--- a/maas/client/flesh/files.py
+++ b/maas/client/flesh/files.py
@@ -5,19 +5,19 @@ __all__ = [
 ]
 
 from . import (
-    OriginTableCommand,
+    OriginPagedTableCommand,
     tables,
 )
 
 
-class cmd_list_files(OriginTableCommand):
+class cmd_files(OriginPagedTableCommand):
     """List files."""
 
     def execute(self, origin, options, target):
         table = tables.FilesTable()
-        print(table.render(target, origin.Files.read()))
+        return table.render(target, origin.Files.read())
 
 
 def register(parser):
     """Register profile commands with the given parser."""
-    cmd_list_files.register(parser)
+    cmd_files.register(parser)

--- a/maas/client/flesh/machines.py
+++ b/maas/client/flesh/machines.py
@@ -1,0 +1,118 @@
+"""Commands for machines."""
+
+__all__ = [
+    "register",
+]
+
+from time import sleep
+
+from . import (
+    colorized,
+    CommandError,
+    OriginTableCommand,
+    OriginPagedTableCommand,
+    tables,
+)
+from .. import utils
+
+
+class cmd_machines(OriginPagedTableCommand):
+    """List all machines."""
+
+    def execute(self, origin, options, target):
+        table = tables.MachinesTable()
+        return table.render(target, origin.Machines.read())
+
+
+class cmd_allocate(OriginTableCommand):
+    """Allocate a machine."""
+
+    def __init__(self, parser):
+        super(cmd_allocate, self).__init__(parser)
+        parser.add_argument("--hostname")
+        parser.add_argument("--architecture")
+        parser.add_argument("--cpus", type=int)
+        parser.add_argument("--memory", type=float)
+        parser.add_argument("--tags", default="")
+
+    def allocate(self, origin, options):
+        return origin.Machines.allocate(
+            hostname=options.hostname, architecture=options.architecture,
+            cpus=options.cpus, memory=options.memory,
+            tags=options.tags.split())
+
+    def execute(self, origin, options, target):
+        machine = self.allocate(origin, options)
+        table = tables.NodesTable()
+        print(table.render(target, [machine]))
+
+
+class cmd_launch(cmd_allocate):
+    """Allocate and deploy a machine."""
+
+    def __init__(self, parser):
+        super(cmd_launch, self).__init__(parser)
+        parser.add_argument(
+            "--wait", type=int, default=0, help=(
+                "Number of seconds to wait for deploy to complete."))
+
+    def execute(self, origin, options, target):
+        machine = self.allocate(origin, options)
+        table = tables.NodesTable()
+
+        print(colorized("{automagenta}DEPLOYING:{/automagenta}"))
+        print(table.render(target, [machine]))
+
+        with utils.Spinner():
+            machine = machine.deploy()
+            for elapsed, remaining, wait in utils.retries(options.wait, 1.0):
+                if machine.status_name == "Deploying":
+                    sleep(wait)
+                    machine = origin.Machine.read(system_id=machine.system_id)
+                else:
+                    break
+
+        if machine.status_name == "Deployed":
+            print(colorized("{autogreen}DEPLOYED:{/autogreen}"))
+            print(table.render(target, [machine]))
+        else:
+            print(colorized("{autored}FAILED TO DEPLOY:{/autored}"))
+            print(table.render(target, [machine]))
+            raise CommandError("Machine was not deployed.")
+
+
+class cmd_release(OriginTableCommand):
+    """Release a machine."""
+
+    def __init__(self, parser):
+        super(cmd_release, self).__init__(parser)
+        parser.add_argument("--system-id", required=True)
+        parser.add_argument(
+            "--wait", type=int, default=0, help=(
+                "Number of seconds to wait for release to complete."))
+
+    def execute(self, origin, options, target):
+        machine = origin.Machine.read(system_id=options.system_id)
+        machine = machine.release()
+
+        with utils.Spinner():
+            for elapsed, remaining, wait in utils.retries(options.wait, 1.0):
+                if machine.status_name == "Releasing":
+                    sleep(wait)
+                    machine = origin.Machine.read(system_id=machine.system_id)
+                else:
+                    break
+
+        table = tables.NodesTable()
+        print(table.render(target, [machine]))
+
+        if machine.status_name != "Ready":
+            raise CommandError("Machine was not released.")
+
+
+def register(parser):
+    """Register commands with the given parser."""
+    cmd_machines.register(parser)
+    cmd_allocate.register(parser)
+    cmd_launch.register(parser)
+    cmd_release.register(parser)

--- a/maas/client/flesh/nodes.py
+++ b/maas/client/flesh/nodes.py
@@ -4,162 +4,20 @@ __all__ = [
     "register",
 ]
 
-import asyncio
-from itertools import chain
-from time import sleep
-
 from . import (
-    colorized,
-    CommandError,
-    OriginTableCommand,
+    OriginPagedTableCommand,
     tables,
 )
-from .. import utils
-from ..utils.async import asynchronous
 
 
-class cmd_allocate_machine(OriginTableCommand):
-    """Allocate a machine."""
-
-    def __init__(self, parser):
-        super(cmd_allocate_machine, self).__init__(parser)
-        parser.add_argument("--hostname")
-        parser.add_argument("--architecture")
-        parser.add_argument("--cpus", type=int)
-        parser.add_argument("--memory", type=float)
-        parser.add_argument("--tags", default="")
-
-    def allocate(self, origin, options):
-        return origin.Machines.allocate(
-            hostname=options.hostname, architecture=options.architecture,
-            cpus=options.cpus, memory=options.memory,
-            tags=options.tags.split())
+class cmd_nodes(OriginPagedTableCommand):
+    """List all nodes."""
 
     def execute(self, origin, options, target):
-        machine = self.allocate(origin, options)
         table = tables.NodesTable()
-        print(table.render(target, [machine]))
-
-
-class cmd_launch_machine(cmd_allocate_machine):
-    """Allocate and deploy a machine."""
-
-    def __init__(self, parser):
-        super(cmd_launch_machine, self).__init__(parser)
-        parser.add_argument(
-            "--wait", type=int, default=0, help=(
-                "Number of seconds to wait for deploy to complete."))
-
-    def execute(self, origin, options, target):
-        machine = self.allocate(origin, options)
-        table = tables.NodesTable()
-
-        print(colorized("{automagenta}DEPLOYING:{/automagenta}"))
-        print(table.render(target, [machine]))
-
-        with utils.Spinner():
-            machine = machine.deploy()
-            for elapsed, remaining, wait in utils.retries(options.wait, 1.0):
-                if machine.status_name == "Deploying":
-                    sleep(wait)
-                    machine = origin.Machine.read(system_id=machine.system_id)
-                else:
-                    break
-
-        if machine.status_name == "Deployed":
-            print(colorized("{autogreen}DEPLOYED:{/autogreen}"))
-            print(table.render(target, [machine]))
-        else:
-            print(colorized("{autored}FAILED TO DEPLOY:{/autored}"))
-            print(table.render(target, [machine]))
-            raise CommandError("Machine was not deployed.")
-
-
-class cmd_release_machine(OriginTableCommand):
-    """Release a machine."""
-
-    def __init__(self, parser):
-        super(cmd_release_machine, self).__init__(parser)
-        parser.add_argument("--system-id", required=True)
-        parser.add_argument(
-            "--wait", type=int, default=0, help=(
-                "Number of seconds to wait for release to complete."))
-
-    def execute(self, origin, options, target):
-        machine = origin.Machine.read(system_id=options.system_id)
-        machine = machine.release()
-
-        with utils.Spinner():
-            for elapsed, remaining, wait in utils.retries(options.wait, 1.0):
-                if machine.status_name == "Releasing":
-                    sleep(wait)
-                    machine = origin.Machine.read(system_id=machine.system_id)
-                else:
-                    break
-
-        table = tables.NodesTable()
-        print(table.render(target, [machine]))
-
-        if machine.status_name != "Ready":
-            raise CommandError("Machine was not released.")
-
-
-class cmd_list_nodes(OriginTableCommand):
-    """List machine, devices, rack & region controllers."""
-
-    def __init__(self, parser):
-        super(cmd_list_nodes, self).__init__(parser)
-        parser.add_argument(
-            "--all", action="store_true", default=False,
-            help="Show all (machines, devices, rack & region controllers).")
-        parser.add_argument(
-            "--devices", action="store_true", default=False,
-            help="Show devices.")
-        parser.add_argument(
-            "--machines", action="store_true", default=False,
-            help="Show machines.")
-        parser.add_argument(
-            "--rack-controllers", action="store_true", default=False,
-            help="Show rack-controllers.")
-        parser.add_argument(
-            "--region-controllers", action="store_true", default=False,
-            help="Show region controllers.")
-
-    @asynchronous
-    async def execute(self, origin, options, target):
-        nodesets = []
-
-        if options.all or options.devices:
-            nodesets.append(origin.Devices)
-        if options.all or options.machines:
-            nodesets.append(origin.Machines)
-        if options.all or options.rack_controllers:
-            nodesets.append(origin.RackControllers)
-        if options.all or options.region_controllers:
-            nodesets.append(origin.RegionControllers)
-
-        if len(nodesets) == 0:
-            nodesets.append(origin.Machines)
-
-        # Don't make more than two concurrent requests to MAAS.
-        semaphore = asyncio.Semaphore(2)
-
-        async def read(nodeset):
-            async with semaphore:
-                return await nodeset.read()
-
-        nodesets = await asyncio.gather(*map(read, nodesets))
-        nodes = chain.from_iterable(nodesets)
-
-        nodes = list(nodes)
-
-        table = tables.NodesTable()
-        print(table.render(target, nodes))
+        return table.render(target, origin.Nodes.read())
 
 
 def register(parser):
     """Register commands with the given parser."""
-    cmd_list_nodes.register(parser, "list")
-    cmd_allocate_machine.register(parser, "allocate")
-    cmd_launch_machine.register(parser, "launch")
-    cmd_release_machine.register(parser, "release")
+    cmd_nodes.register(parser)

--- a/maas/client/flesh/profiles.py
+++ b/maas/client/flesh/profiles.py
@@ -9,6 +9,7 @@ import sys
 from . import (
     colorized,
     Command,
+    print_with_pager,
     PROFILE_DEFAULT,
     PROFILE_NAMES,
     read_input,
@@ -179,6 +180,11 @@ class cmd_profiles(TableCommand):
                 "all profiles. Use it to update your command-line client's "
                 "information after an upgrade to the MAAS server."),
         )
+        parser.other.add_argument(
+            "--no-pager", action='store_true',
+            help=(
+                "Don't use the pager when printing the output of the "
+                "command."))
 
     def __call__(self, options):
         if options.refresh:
@@ -191,7 +197,10 @@ class cmd_profiles(TableCommand):
         else:
             table = tables.ProfilesTable()
             with profiles.ProfileStore.open() as config:
-                print(table.render(options.format, config))
+                if options.no_pager:
+                    print(table.render(options.format, config))
+                else:
+                    print_with_pager(table.render(options.format, config))
 
 
 def register(parser):

--- a/maas/client/flesh/tabular.py
+++ b/maas/client/flesh/tabular.py
@@ -124,6 +124,9 @@ class Column:
                 return ""
             elif isinstance(datum, colorclass.Color):
                 return datum.value_no_colors
+            elif (isinstance(datum, collections.Iterable) and
+                    not isinstance(datum, (str, bytes))):
+                return "\n".join(datum)
             else:
                 return str(datum)
         elif target is RenderTarget.pretty:
@@ -131,6 +134,9 @@ class Column:
                 return ""
             elif isinstance(datum, colorclass.Color):
                 return datum
+            elif (isinstance(datum, collections.Iterable) and
+                    not isinstance(datum, (str, bytes))):
+                return "\n".join(datum)
             else:
                 return str(datum)
         else:

--- a/maas/client/flesh/tags.py
+++ b/maas/client/flesh/tags.py
@@ -5,19 +5,19 @@ __all__ = [
 ]
 
 from . import (
-    OriginTableCommand,
+    OriginPagedTableCommand,
     tables,
 )
 
 
-class cmd_list_tags(OriginTableCommand):
+class cmd_tags(OriginPagedTableCommand):
     """List tags."""
 
     def execute(self, origin, options, target):
         table = tables.TagsTable()
-        print(table.render(target, origin.Tags.read()))
+        return table.render(target, origin.Tags.read())
 
 
 def register(parser):
     """Register profile commands with the given parser."""
-    cmd_list_tags.register(parser)
+    cmd_tags.register(parser)

--- a/maas/client/flesh/tests/test_controllers.py
+++ b/maas/client/flesh/tests/test_controllers.py
@@ -1,0 +1,100 @@
+"""Tests for `maas.client.flesh.controllers`."""
+
+from operator import itemgetter
+import yaml
+
+from .. import (
+    ArgumentParser,
+    controllers,
+    tabular
+)
+from ...enum import NodeType
+from ...testing import (
+    make_name_without_spaces,
+    TestCase
+)
+from ...viscera.testing import bind
+from ...viscera.controllers import (
+    RackController,
+    RackControllers,
+    RegionController,
+    RegionControllers
+)
+
+
+def make_origin():
+    """Make origin for controllers."""
+    return bind(
+        RackControllers, RackController,
+        RegionController, RegionControllers)
+
+
+class TestControllers(TestCase):
+    """Tests for `cmd_controllers`."""
+
+    def test_returns_table_with_controllers(self):
+        origin = make_origin()
+        parser = ArgumentParser()
+        region_rack_id = make_name_without_spaces()
+        region_rack_hostname = make_name_without_spaces()
+        racks = [
+            {
+                'system_id': region_rack_id,
+                'hostname': region_rack_hostname,
+                'node_type': NodeType.REGION_AND_RACK_CONTROLLER.value,
+                'architecture': 'amd64/generic',
+                'cpu_count': 2,
+                'memory': 1024,
+            },
+            {
+                'system_id': make_name_without_spaces(),
+                'hostname': make_name_without_spaces(),
+                'node_type': NodeType.RACK_CONTROLLER.value,
+                'architecture': 'amd64/generic',
+                'cpu_count': 2,
+                'memory': 1024,
+            },
+        ]
+        regions = [
+            {
+                'system_id': region_rack_id,
+                'hostname': region_rack_hostname,
+                'node_type': NodeType.REGION_AND_RACK_CONTROLLER.value,
+                'architecture': 'amd64/generic',
+                'cpu_count': 2,
+                'memory': 1024,
+            },
+            {
+                'system_id': make_name_without_spaces(),
+                'hostname': make_name_without_spaces(),
+                'node_type': NodeType.REGION_CONTROLLER.value,
+                'architecture': 'amd64/generic',
+                'cpu_count': 2,
+                'memory': 1024,
+            },
+        ]
+        origin.RackControllers._handler.read.return_value = racks
+        origin.RegionControllers._handler.read.return_value = regions
+        cmd = controllers.cmd_controllers(parser)
+        output = yaml.load(
+            cmd.execute(origin, {}, target=tabular.RenderTarget.yaml))
+        self.assertEquals([
+            {'name': 'hostname', 'title': 'Hostname'},
+            {'name': 'node_type', 'title': 'Type'},
+            {'name': 'architecture', 'title': 'Arch'},
+            {'name': 'cpus', 'title': '#CPUs'},
+            {'name': 'memory', 'title': 'RAM'},
+        ], output['columns'])
+        controller_output = {
+            controller['hostname']: {
+                'hostname': controller['hostname'],
+                'node_type': controller['node_type'],
+                'architecture': controller['architecture'],
+                'cpus': controller['cpu_count'],
+                'memory': controller['memory'],
+            }
+            for controller in racks + regions
+        }
+        self.assertEquals(
+            sorted(controller_output.values(), key=itemgetter('hostname')),
+            output['data'])

--- a/maas/client/flesh/tests/test_devices.py
+++ b/maas/client/flesh/tests/test_devices.py
@@ -1,0 +1,104 @@
+"""Tests for `maas.client.flesh.devices`."""
+
+from operator import itemgetter
+import yaml
+
+from .. import (
+    ArgumentParser,
+    devices,
+    tabular
+)
+from ...testing import (
+    make_name_without_spaces,
+    TestCase
+)
+from ...viscera.testing import bind
+from ...viscera.devices import (
+    Device,
+    Devices
+)
+from ...viscera.interfaces import (
+    Interface,
+    Interfaces,
+    InterfaceLink,
+    InterfaceLinks,
+)
+
+
+def make_origin():
+    """Make origin for devices."""
+    return bind(
+        Devices, Device,
+        Interfaces, Interface,
+        InterfaceLinks, InterfaceLink)
+
+
+class TestDevices(TestCase):
+    """Tests for `cmd_devices`."""
+
+    def test_returns_table_with_devices(self):
+        origin = make_origin()
+        parser = ArgumentParser()
+        devices_objs = [
+            {
+                'hostname': make_name_without_spaces(),
+                'interface_set': [
+                    {
+                        'links': [
+                            {'ip_address': '192.168.122.1'}
+                        ],
+                    },
+                    {
+                        'links': [
+                            {'ip_address': '192.168.122.2'}
+                        ],
+                    },
+                    {
+                        'links': [
+                            {}
+                        ],
+                    },
+                ],
+            },
+            {
+                'hostname': make_name_without_spaces(),
+                'interface_set': [
+                    {
+                        'links': [
+                            {'ip_address': '192.168.122.10'}
+                        ],
+                    },
+                    {
+                        'links': [
+                            {'ip_address': '192.168.122.11'}
+                        ],
+                    },
+                    {
+                        'links': [
+                            {}
+                        ],
+                    },
+                ],
+            },
+        ]
+        origin.Devices._handler.read.return_value = devices_objs
+        cmd = devices.cmd_devices(parser)
+        output = yaml.load(
+            cmd.execute(origin, {}, target=tabular.RenderTarget.yaml))
+        self.assertEquals([
+            {'name': 'hostname', 'title': 'Hostname'},
+            {'name': 'ip_addresses', 'title': 'IP addresses'},
+        ], output['columns'])
+        devices_output = sorted([
+            {
+                'hostname': device['hostname'],
+                'ip_addresses': [
+                    link['ip_address']
+                    for nic in device['interface_set']
+                    for link in nic['links']
+                    if link.get('ip_address')
+                ]
+            }
+            for device in devices_objs
+        ], key=itemgetter('hostname'))
+        self.assertEquals(devices_output, output['data'])

--- a/maas/client/flesh/tests/test_machines.py
+++ b/maas/client/flesh/tests/test_machines.py
@@ -1,0 +1,80 @@
+"""Tests for `maas.client.flesh.machines`."""
+
+from operator import itemgetter
+import yaml
+
+from .. import (
+    ArgumentParser,
+    machines,
+    tabular
+)
+from ...enum import (
+    NodeStatus,
+    PowerState
+)
+from ...testing import (
+    make_name_without_spaces,
+    TestCase
+)
+from ...viscera.testing import bind
+from ...viscera.machines import (
+    Machine,
+    Machines
+)
+
+
+def make_origin():
+    """Make origin for machines."""
+    return bind(Machines, Machine)
+
+
+class TestMachines(TestCase):
+    """Tests for `cmd_machines`."""
+
+    def test_returns_table_with_machines(self):
+        origin = make_origin()
+        parser = ArgumentParser()
+        machine_objs = [
+            {
+                'hostname': make_name_without_spaces(),
+                'architecture': 'amd64/generic',
+                'status': NodeStatus.READY.value,
+                'status_name': NodeStatus.READY.name,
+                'power_state': PowerState.OFF.value,
+                'cpu_count': 2,
+                'memory': 1024,
+            },
+            {
+                'hostname': make_name_without_spaces(),
+                'architecture': 'i386/generic',
+                'status': NodeStatus.DEPLOYED.value,
+                'status_name': NodeStatus.DEPLOYED.name,
+                'power_state': PowerState.ON.value,
+                'cpu_count': 4,
+                'memory': 4096,
+            },
+        ]
+        origin.Machines._handler.read.return_value = machine_objs
+        cmd = machines.cmd_machines(parser)
+        output = yaml.load(
+            cmd.execute(origin, {}, target=tabular.RenderTarget.yaml))
+        self.assertEquals([
+            {'name': 'hostname', 'title': 'Hostname'},
+            {'name': 'power', 'title': 'Power'},
+            {'name': 'status', 'title': 'Status'},
+            {'name': 'architecture', 'title': 'Arch'},
+            {'name': 'cpus', 'title': '#CPUs'},
+            {'name': 'memory', 'title': 'RAM'},
+        ], output['columns'])
+        machines_output = sorted([
+            {
+                'hostname': machine['hostname'],
+                'power': machine['power_state'],
+                'status': machine['status_name'],
+                'architecture': machine['architecture'],
+                'cpus': machine['cpu_count'],
+                'memory': machine['memory'],
+            }
+            for machine in machine_objs
+        ], key=itemgetter('hostname'))
+        self.assertEquals(machines_output, output['data'])

--- a/maas/client/flesh/tests/test_nodes.py
+++ b/maas/client/flesh/tests/test_nodes.py
@@ -1,0 +1,71 @@
+"""Tests for `maas.client.flesh.nodes`."""
+
+from operator import itemgetter
+import yaml
+
+from .. import (
+    ArgumentParser,
+    nodes,
+    tabular
+)
+from ...enum import NodeType
+from ...testing import (
+    make_name_without_spaces,
+    TestCase
+)
+from ...viscera.testing import bind
+from ...viscera.nodes import (
+    Node,
+    Nodes
+)
+
+
+def make_origin():
+    """Make origin for nodes."""
+    return bind(Nodes, Node)
+
+
+class TestNodes(TestCase):
+    """Tests for `cmd_nodes`."""
+
+    def test_returns_table_with_nodes(self):
+        origin = make_origin()
+        parser = ArgumentParser()
+        node_obj = [
+            {
+                'hostname': make_name_without_spaces(),
+                'node_type': NodeType.MACHINE.value,
+            },
+            {
+                'hostname': make_name_without_spaces(),
+                'node_type': NodeType.DEVICE.value,
+            },
+            {
+                'hostname': make_name_without_spaces(),
+                'node_type': NodeType.RACK_CONTROLLER.value,
+            },
+            {
+                'hostname': make_name_without_spaces(),
+                'node_type': NodeType.REGION_CONTROLLER.value,
+            },
+            {
+                'hostname': make_name_without_spaces(),
+                'node_type': NodeType.REGION_AND_RACK_CONTROLLER.value,
+            },
+        ]
+        origin.Nodes._handler.read.return_value = node_obj
+        cmd = nodes.cmd_nodes(parser)
+        output = yaml.load(
+            cmd.execute(origin, {}, target=tabular.RenderTarget.yaml))
+        self.assertEquals([
+            {'name': 'hostname', 'title': 'Hostname'},
+            {'name': 'node_type', 'title': 'Type'},
+        ], output['columns'])
+        nodes_output = sorted([
+            {
+                'hostname': node['hostname'],
+                'node_type': node['node_type'],
+            }
+            for node in node_obj
+        ], key=itemgetter('hostname'))
+        self.assertEquals(nodes_output, output['data'])

--- a/maas/client/flesh/users.py
+++ b/maas/client/flesh/users.py
@@ -5,19 +5,19 @@ __all__ = [
 ]
 
 from . import (
-    OriginTableCommand,
+    OriginPagedTableCommand,
     tables,
 )
 
 
-class cmd_list_users(OriginTableCommand):
+class cmd_users(OriginPagedTableCommand):
     """List users."""
 
     def execute(self, origin, options, target):
         table = tables.UsersTable()
-        print(table.render(target, origin.Users.read()))
+        return table.render(target, origin.Users.read())
 
 
 def register(parser):
     """Register profile commands with the given parser."""
-    cmd_list_users.register(parser)
+    cmd_users.register(parser)

--- a/scripts/check-imports
+++ b/scripts/check-imports
@@ -520,6 +520,7 @@ checks = [
             Allow("testscenarios|testscenarios.**"),
             Allow("testtools|testtools.**"),
             Allow("twisted|twisted.**"),
+            Allow("yaml|yaml.**"),
             Allow(StandardLibraries),
         ),
     ),


### PR DESCRIPTION
All `list-*` commands have be refactored to:

`nodes` - List nodes.
`machines` - List machines.
`devices` - List devices.
`controllers` - List controllers.
`files` - List files.
`tags` - List tags.
`users` - List users.

This also adds paging output to all read only outputs from the CLI. This includes all listing commands and help commands.

Updates the documentation to use the new CLI design instead of the old design.