### PR TITLE
Correctly handle RaidLevel in viscera.raids.create()

### DIFF
--- a/maas/client/viscera/raids.py
+++ b/maas/client/viscera/raids.py
@@ -110,6 +110,8 @@ class RaidsType(ObjectType):
         :type spare_devices: iterable of mixed type of `BlockDevice` or
             `Partition`
         """
+        if isinstance(level, RaidLevel):
+            level = level.value
         params = {
             'level': str(level),
         }


### PR DESCRIPTION
When the RAID level is given as a RaidLevel enum, use the enum value
rather than converting it to a string directly.