### PR TITLE
Return machine boot_disk as BlockDevice

### DIFF
--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -318,8 +318,8 @@ class Machine(Node, metaclass=MachineType):
 
     architecture = ObjectField.Checked(
         "architecture", check_optional(str), check_optional(str))
-    boot_disk = ObjectField.Checked(
-        "boot_disk", check_optional(str), check_optional(str))
+    boot_disk = ObjectFieldRelated(
+        "boot_disk", "BlockDevice", readonly=True)
     cpus = ObjectField.Checked(
         "cpu_count", check(int), check(int))
     disable_ipv4 = ObjectField.Checked(


### PR DESCRIPTION
Trying to read `boot_disk` on a `machines` instance returns a
`TypeError`:

```
{'name': 'sda', ...} is not of type (<class 'str'>, <class 'NoneType'>)
```

The commit defines `boot_disk` as a `BlockDevice` instead, which returns
the expected object.