### PR TITLE
Audit event logging

### DIFF
--- a/doc/client/events.md
+++ b/doc/client/events.md
@@ -18,6 +18,7 @@ This accepts a plethora of optional arguments to narrow down the results:
 >>> events = client.events.query(agent_name=…)
 >>> events = client.events.query(level=…)
 >>> events = client.events.query(after=…, limit=…)
+>>> events = client.events.query(owner=…)
 ```
 
 These arguments can be combined to narrow the results even further.

--- a/doc/viscera/events.md
+++ b/doc/viscera/events.md
@@ -18,6 +18,7 @@ This accepts a plethora of optional arguments to narrow down the results:
 >>> events = origin.Events.query(agent_name=…)
 >>> events = origin.Events.query(level=…)
 >>> events = origin.Events.query(after=…, limit=…)
+>>> events = origin.events.query(owner=…)
 ```
 
 These arguments can be combined to narrow the results even further.

--- a/maas/client/viscera/events.py
+++ b/maas/client/viscera/events.py
@@ -43,7 +43,8 @@ from ..utils.async import is_loop_running
 #         level=event.type.level_str,
 #         created=event.created.strftime('%a, %d %b. %Y %H:%M:%S'),
 #         type=event.type.description,
-#         description=event.description
+#         description=event.description,
+#         username=event.user.username
 #     )
 #
 # Notes:
@@ -57,6 +58,7 @@ class Level(enum.IntEnum):
     They happen to correspond to levels in the `logging` module.
     """
 
+    AUDIT = 0
     DEBUG = logging.DEBUG
     INFO = logging.INFO
     WARNING = logging.WARNING
@@ -93,7 +95,8 @@ class EventsType(ObjectType):
             level: typing.Union[Level, int, str]=None,
             before: int=None,
             after: int=None,
-            limit: int=None):
+            limit: int=None,
+            owner: str=None):
         """Query MAAS for matching events."""
 
         if before is not None and after is not None:
@@ -122,6 +125,8 @@ class EventsType(ObjectType):
             params["after"] = ["{:d}".format(after)]
         if limit is not None:
             params["limit"] = ["{:d}".format(limit)]
+        if owner is not None:
+            params["owner"] = [owner]
 
         data = await cls._handler.query(**params)
         return cls(data)
@@ -298,6 +303,9 @@ class Event(Object):
         "description", readonly=True)
     description_short = ObjectField.Checked(
         "description", partial(truncate, 50), readonly=True)
+
+    username = ObjectField(
+        "username", readonly=True)
 
     def __repr__(self):
         return (

--- a/maas/client/viscera/tests/test_events.py
+++ b/maas/client/viscera/tests/test_events.py
@@ -35,6 +35,7 @@ def make_Event_dict():
         "level": random.choice(list(events.Level)),
         "created": datetime.utcnow().strftime("%a, %d %b. %Y %H:%M:%S"),
         "description": make_name_without_spaces("description"),
+        "username": make_name_without_spaces("username")
     }
 
 
@@ -90,6 +91,7 @@ class TestEventsQuery(TestCase):
             "agent_name": make_name_without_spaces("agent"),
             "level": random.choice(list(events.Level)),
             "limit": random.randrange(1, 1000),
+            "owner": make_name_without_spaces("username"),
         }
         obj.query(**arguments)
         expected = {
@@ -101,6 +103,7 @@ class TestEventsQuery(TestCase):
             "agent_name": [arguments["agent_name"]],
             "level": [arguments["level"].name],
             "limit": [str(arguments["limit"])],
+            "owner": [arguments["owner"]],
         }
         obj._handler.query.assert_called_once_with(**expected)
 


### PR DESCRIPTION
Updates events so that audit events are supported.  Now a user can pass an owner or a level=client.events.AUDIT argument to the events query as is possible in the MAAS API.