### PR TITLE
Add ability to change the fabric a vlan belongs

### DIFF
--- a/maas/client/viscera/vlans.py
+++ b/maas/client/viscera/vlans.py
@@ -78,6 +78,9 @@ class Vlan(Object, metaclass=VlanType):
             fields={"name", "vid"})
 
     async def save(self):
+        # Store fabric_id so its reset on save. `fabric_id` is not returned
+        # by the API, this is stored through `local_data`.
+        fabric_id = self._data['fabric_id']
         if ('fabric_id' in self._changed_data and
                 self._changed_data['fabric_id']):
             if (self._orig_data['fabric_id'] and
@@ -91,6 +94,8 @@ class Vlan(Object, metaclass=VlanType):
                 # with the new 'fabric_id'.
                 self._changed_data['fabric'] = self._changed_data['fabric_id']
         await super(Vlan, self).save()
+        # Set fabric_id because it was lost from the `save`.
+        self._data['fabric_id'] = fabric_id
 
     async def delete(self):
         """Delete this VLAN."""

--- a/maas/client/viscera/vlans.py
+++ b/maas/client/viscera/vlans.py
@@ -52,7 +52,7 @@ class Vlan(Object, metaclass=VlanType):
         "id", check(int), readonly=True)
 
     fabric = ObjectFieldRelated(
-        "fabric_id", "Fabric", readonly=True, pk=0)
+        "fabric_id", "Fabric", pk=0)
     vid = ObjectField.Checked(
         "vid", check(int), check(int), pk=1)
 
@@ -76,6 +76,21 @@ class Vlan(Object, metaclass=VlanType):
     def __repr__(self):
         return super(Vlan, self).__repr__(
             fields={"name", "vid"})
+
+    async def save(self):
+        if ('fabric_id' in self._changed_data and
+                self._changed_data['fabric_id']):
+            if (self._orig_data['fabric_id'] and
+                    self._changed_data['fabric_id'] == (
+                        self._orig_data['fabric_id'])):
+                # Fabric didn't really change, the object was just set to the
+                # same Fabric
+                del self._changed_data['fabric_id']
+            else:
+                # Allow the update of the fabric by setting the 'fabric' field
+                # with the new 'fabric_id'.
+                self._changed_data['fabric'] = self._changed_data['fabric_id']
+        await super(Vlan, self).save()
 
     async def delete(self):
         """Delete this VLAN."""


### PR DESCRIPTION
Fixes #174. 

Adds missing tests in test_vlans.py. Tests were original copied from test_fabrics.py but the tests where not actually updated, they where just testing fabrics.