### PR TITLE
Allow updating the vid of a VLAN object.

### DIFF
--- a/maas/client/viscera/tests/test_vlans.py
+++ b/maas/client/viscera/tests/test_vlans.py
@@ -166,5 +166,28 @@ class TestVlan(TestCase):
         }
         vlan.save()
         Vlan._handler.update.assert_called_once_with(
-            fabric_id=fabric_id, vid=vid, fabric=new_fabric.id)
+            fabric_id=fabric_id, vid=vid, _vid=vid, fabric=new_fabric.id)
         self.assertThat(vlan.fabric.id, Equals(new_fabric.id))
+
+    def test__vlan_update_vid(self):
+        origin = make_origin()
+        Vlan = origin.Vlan
+        Vlan._handler.params = ['fabric_id', 'vid']
+        fabric_id = random.randint(1, 100)
+        vlan_id = random.randint(5001, 6000)
+        vid = random.randint(100, 200)
+        new_vid = random.randint(201, 300)
+        vlan = Vlan({
+            "id": vlan_id,
+            "fabric_id": fabric_id,
+            "vid": vid,
+        })
+        vlan.vid = new_vid
+        Vlan._handler.update.return_value = {
+            "id": vlan_id,
+            "vid": new_vid,
+        }
+        vlan.save()
+        Vlan._handler.update.assert_called_once_with(
+            fabric_id=fabric_id, vid=vid, _vid=new_vid)
+        self.assertThat(new_vid, Equals(new_vid))

--- a/maas/client/viscera/vlans.py
+++ b/maas/client/viscera/vlans.py
@@ -93,7 +93,20 @@ class Vlan(Object, metaclass=VlanType):
                 # Allow the update of the fabric by setting the 'fabric' field
                 # with the new 'fabric_id'.
                 self._changed_data['fabric'] = self._changed_data['fabric_id']
-        await super(Vlan, self).save()
+
+        # Don't call `super().save()` because `vid` can be changed and it has
+        # to be handled specially because its in the resource_uri path.
+        if self._changed_data:
+            update_data = dict(self._changed_data)
+            update_data.update({
+                key: self._orig_data[key]
+                for key in self._handler.params
+            })
+            update_data['vid'] = update_data['_vid'] = self._orig_data['vid']
+            if 'vid' in self._changed_data:
+                update_data['_vid'] = self._changed_data['vid']
+            self._data = await self._handler.update(**update_data)
+
         # Set fabric_id because it was lost from the `save`.
         self._data['fabric_id'] = fabric_id
 


### PR DESCRIPTION
Fixes #177.

Because the `vid` is also in the resource_uri, updating the `vid` needs to be special cased.