### PR TITLE
Add porcelain around specifying no tests should be run during commissioning (#185)

### DIFF
--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -471,8 +471,8 @@ class Machine(Node, metaclass=MachineType):
                 len(commissioning_scripts) > 0):
             params["commissioning_scripts"] = ",".join(commissioning_scripts)
         if testing_scripts is not None:
-            if len(testing_scripts) == 0:
-                params["testing_scripts"] = ""
+            if len(testing_scripts) == 0 or testing_scripts == "none":
+                params["testing_scripts"] = ["none"]
             else:
                 params["testing_scripts"] = ",".join(testing_scripts)
         self._data = await self._handler.commission(**params)


### PR DESCRIPTION
By default Django forms use the value '' meaning no input was given. MAAS interprets this as meaning run the default set of tests. This adds a bit of porcelain to python-libmaas so passing '', [], or 'none' will send ['none'] which disables running testing.