### PR TITLE
Pin flake8 to 3.6.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 commands = flake8 maas --isolated --ignore=E402,E123,E731,W504,W605
 sitepackages = False
 skip_install = True
-deps = flake8
+deps = flake8==3.6.0
 
 [testenv:imports]
 commands = {toxinidir}/scripts/check-imports


### PR DESCRIPTION
Due to https://github.com/PyCQA/pyflakes/issues/427, pin flake8 to 3.6.0 so the false positive doesn't occur.