### PR TITLE
Fix power_parameters JSON parsing error

### DIFF
--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -100,7 +100,7 @@ class MachinesType(NodesType):
             "power_type": power_type,
         }
         if power_parameters is not None:
-            params["power_parameters"] = json.dumps(power_parameters)
+            params["power_parameters"] = json.dumps(power_parameters, sort_keys=True)
         if subarchitecture is not None:
             params["subarchitecture"] = subarchitecture
         if min_hwe_kernel is not None:

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -100,7 +100,8 @@ class MachinesType(NodesType):
             "power_type": power_type,
         }
         if power_parameters is not None:
-            params["power_parameters"] = json.dumps(power_parameters, sort_keys=True)
+            params["power_parameters"] = json.dumps(
+                power_parameters, sort_keys=True)
         if subarchitecture is not None:
             params["subarchitecture"] = subarchitecture
         if min_hwe_kernel is not None:

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -8,6 +8,7 @@ __all__ = [
 import asyncio
 import base64
 import bson
+import json
 from http import HTTPStatus
 import typing
 
@@ -99,7 +100,7 @@ class MachinesType(NodesType):
             "power_type": power_type,
         }
         if power_parameters is not None:
-            params["power_parameters"] = power_parameters
+            params["power_parameters"] = json.dumps(power_parameters)
         if subarchitecture is not None:
             params["subarchitecture"] = subarchitecture
         if min_hwe_kernel is not None:

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -923,8 +923,10 @@ class TestMachines(TestCase):
             architecture='amd64',
             mac_addresses=['00:11:22:33:44:55', '00:11:22:33:44:AA'],
             power_type='ipmi',
-            power_parameters=('{"power_address": "localhost", '
-                '"power_user": "root"}'),
+            power_parameters=(
+                '{"power_address": "localhost", '
+                '"power_user": "root"}'
+            ),
             subarchitecture='generic',
             min_hwe_kernel='hwe-x',
             hostname='new-machine',

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -923,8 +923,8 @@ class TestMachines(TestCase):
             architecture='amd64',
             mac_addresses=['00:11:22:33:44:55', '00:11:22:33:44:AA'],
             power_type='ipmi',
-            power_parameters={
-                'power_address': 'localhost', 'power_user': 'root'},
+            power_parameters='{
+                "power_address": "localhost", "power_user": "root"}',
             subarchitecture='generic',
             min_hwe_kernel='hwe-x',
             hostname='new-machine',

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -923,7 +923,8 @@ class TestMachines(TestCase):
             architecture='amd64',
             mac_addresses=['00:11:22:33:44:55', '00:11:22:33:44:AA'],
             power_type='ipmi',
-            power_parameters='{"power_address": "localhost", "power_user": "root"}',
+            power_parameters=('{"power_address": "localhost", '
+                '"power_user": "root"}'),
             subarchitecture='generic',
             min_hwe_kernel='hwe-x',
             hostname='new-machine',

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -923,8 +923,7 @@ class TestMachines(TestCase):
             architecture='amd64',
             mac_addresses=['00:11:22:33:44:55', '00:11:22:33:44:AA'],
             power_type='ipmi',
-            power_parameters='{
-                "power_address": "localhost", "power_user": "root"}',
+            power_parameters='{"power_address": "localhost", "power_user": "root"}',
             subarchitecture='generic',
             min_hwe_kernel='hwe-x',
             hostname='new-machine',


### PR DESCRIPTION
Fixes the _CallError_ when creating a machine with the `power_parameters` dict parameter.

```
client.bones.CallError: POST http://<maas_server>:5240/MAAS/api/2.0/machines/ -> HTTP 400 Bad Request (Failed to parse JSON power_parameters)
```