### PR TITLE
Build the URI using the original scheme of the url also store in the connection is insecure in the profile. Fixes #193.

### DIFF
--- a/maas/client/bones/helpers.py
+++ b/maas/client/bones/helpers.py
@@ -124,7 +124,7 @@ async def connect(url, *, apikey=None, insecure=False):
     # Return a new (unsaved) profile.
     return Profile(
         name=url.netloc, url=url.geturl(), credentials=credentials,
-        description=description)
+        description=description, insecure=insecure)
 
 
 class LoginError(Exception):
@@ -219,7 +219,7 @@ async def login(url, *, anonymous=False, username=None, password=None,
     # Return a new (unsaved) profile.
     return Profile(
         name=profile_name, url=url.geturl(), credentials=credentials,
-        description=description)
+        description=description, insecure=insecure)
 
 
 async def authenticate_with_macaroon(url, insecure=False):

--- a/maas/client/bones/tests/test.py
+++ b/maas/client/bones/tests/test.py
@@ -58,6 +58,13 @@ class TestSessionAPI(TestCase):
             fixture.url, insecure=insecure)
         self.assertThat(session.insecure, Is(insecure))
 
+    async def test__fromURL_sets_scheme_on_session(self):
+        insecure = random.choice((True, False))
+        fixture = self.useFixture(testing.DescriptionServer())
+        session = await bones.SessionAPI.fromURL(
+            fixture.url, insecure=insecure)
+        self.assertThat(session.scheme, Equals('http'))
+
 
 class TestSessionAPI_APIVersions(TestCase):
     """Tests for `SessionAPI` with multiple API versions."""

--- a/maas/client/bones/tests/test_helpers.py
+++ b/maas/client/bones/tests/test_helpers.py
@@ -154,9 +154,11 @@ class TestConnect(TestCase):
         self.assertThat(profile.description, Equals(description))
 
     def test__API_description_is_fetched_insecurely_if_requested(self):
-        helpers.connect("http://example.org:5240/MAAS/", insecure=True)
+        profile = helpers.connect(
+            "http://example.org:5240/MAAS/", insecure=True)
         helpers.fetch_api_description.assert_called_once_with(
             urlparse("http://example.org:5240/MAAS/api/2.0/"), True)
+        self.assertTrue(profile.other['insecure'])
 
 
 class TestLogin(TestCase):
@@ -260,10 +262,12 @@ class TestLogin(TestCase):
         self.assertThat(profile.description, Equals(description))
 
     def test__API_token_is_fetched_insecurely_if_requested(self):
-        helpers.login("http://foo:bar@example.org:5240/MAAS/", insecure=True)
+        profile = helpers.login(
+            "http://foo:bar@example.org:5240/MAAS/", insecure=True)
         helpers.authenticate.assert_called_once_with(
             "http://example.org:5240/MAAS/api/2.0/",
             "foo", "bar", insecure=True)
+        self.assertTrue(profile.other['insecure'])
 
     def test__API_description_is_fetched_insecurely_if_requested(self):
         helpers.login(


### PR DESCRIPTION
Previously the URI would always use http, even if the profiles URL was set to an https scheme. This ensures that the scheme is correct when building the URL for the request.

This branch also fixes another issue that I came across when testing this against a real MAAS server. The profile did not store if the connection was a secure SSL or insecure SSL. Once logged in then using the command line would fail, because the profile did not store that the connection should be allowed as insecure.