### PR TITLE
Support install_kvm when deploying

### DIFF
--- a/maas/client/flesh/machines.py
+++ b/maas/client/flesh/machines.py
@@ -629,6 +629,9 @@ class cmd_deploy(cmd_allocate, MachineSSHMixin, MachineReleaseMixin):
         parser.other.add_argument(
             "--no-wait", action="store_true", help=(
                 "Don't wait for the deploy to complete."))
+        parser.other.add_argument(
+            "--install-kvm", action="store_true", help=(
+                "Install KVM on machine"))
 
     def _get_deploy_options(self, options):
         """Return the deployment options based on command line."""
@@ -645,6 +648,7 @@ class cmd_deploy(cmd_allocate, MachineSSHMixin, MachineReleaseMixin):
             'hwe_kernel': options.hwe_kernel,
             'user_data': user_data,
             'comment': options.comment,
+            'install_kvm': options.install_kvm,
             'wait': False,
         })
 

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -486,7 +486,7 @@ class Machine(Node, metaclass=MachineType):
     async def deploy(
             self, *, user_data: typing.Union[bytes, str] = None,
             distro_series: str = None, hwe_kernel: str = None,
-            comment: str = None, wait: bool = False, 
+            comment: str = None, wait: bool = False,
             install_kvm: bool = False, wait_interval: int = 5):
         """Deploy this machine.
 

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -500,7 +500,11 @@ class Machine(Node, metaclass=MachineType):
         :param wait: If specified, wait until the deploy is complete.
         :param wait_interval: How often to poll, defaults to 5 seconds
         """
-        params = {"system_id": self.system_id, "install_kvm": install_kvm}
+        params = {"system_id": self.system_id}
+
+        if install_kvm:
+            params["install_kvm"] = install_kvm
+
         if user_data is not None:
             if isinstance(user_data, bytes):
                 params["user_data"] = base64.encodebytes(user_data)

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -486,7 +486,8 @@ class Machine(Node, metaclass=MachineType):
     async def deploy(
             self, *, user_data: typing.Union[bytes, str] = None,
             distro_series: str = None, hwe_kernel: str = None,
-            comment: str = None, wait: bool = False, install_kvm: bool = False, wait_interval: int = 5):
+            comment: str = None, wait: bool = False, 
+            install_kvm: bool = False, wait_interval: int = 5):
         """Deploy this machine.
 
         :param user_data: User-data to provide to the machine when booting. If

--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -486,7 +486,7 @@ class Machine(Node, metaclass=MachineType):
     async def deploy(
             self, *, user_data: typing.Union[bytes, str] = None,
             distro_series: str = None, hwe_kernel: str = None,
-            comment: str = None, wait: bool = False, wait_interval: int = 5):
+            comment: str = None, wait: bool = False, install_kvm: bool = False, wait_interval: int = 5):
         """Deploy this machine.
 
         :param user_data: User-data to provide to the machine when booting. If
@@ -500,7 +500,7 @@ class Machine(Node, metaclass=MachineType):
         :param wait: If specified, wait until the deploy is complete.
         :param wait_interval: How often to poll, defaults to 5 seconds
         """
-        params = {"system_id": self.system_id}
+        params = {"system_id": self.system_id, "install_kvm": install_kvm}
         if user_data is not None:
             if isinstance(user_data, bytes):
                 params["user_data"] = base64.encodebytes(user_data)

--- a/maas/client/viscera/tests/test_machines.py
+++ b/maas/client/viscera/tests/test_machines.py
@@ -263,6 +263,26 @@ class TestMachine(TestCase):
             system_id=machine.system_id
         )
 
+    def test__deploy_with_kvm_install(self):
+        system_id = make_name_without_spaces("system-id")
+        hostname = make_name_without_spaces("hostname")
+        data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.READY,
+        }
+        deploying_data = {
+            "system_id": system_id,
+            "hostname": hostname,
+            "status": NodeStatus.DEPLOYING,
+        }
+        machine = make_machines_origin().Machine(data)
+        machine._handler.deploy.return_value = deploying_data
+        machine.deploy(install_kvm=True, wait=False)
+        machine._handler.deploy.assert_called_once_with(
+            system_id=machine.system_id, install_kvm=True,
+        )
+
     def test__deploy_with_wait_failed(self):
         system_id = make_name_without_spaces("system-id")
         hostname = make_name_without_spaces("hostname")


### PR DESCRIPTION
Hi,
When deploying ubuntu/bionic, I needed the "kvm_install" option, as specified in the API documentation: 

> install_kvm (Boolean): Optional. If true, KVM will be installed on this machine and added to MAAS.

Unfortunately I don't have the complete picture of the package, so I don't know if this should be changes somewhere else too to be fully supported.

This example works:
`machine.deploy(distro_series="bionic", install_kvm=True)`

Thanks in advance
EDIT: Sorry I didn't verify my changes pass the tests before creating the PR.