### PR TITLE
Fix machine details for a machine with tags

### DIFF
--- a/maas/client/bones/testing/server.py
+++ b/maas/client/bones/testing/server.py
@@ -22,9 +22,11 @@ class ApplicationBuilder:
         super(ApplicationBuilder, self).__init__()
         self._description = desc.Description(description)
         self._application = aiohttp.web.Application()
-        self._rootpath, self._basepath, self._version = (
-            self._discover_version_and_paths()
-        )
+        (
+            self._rootpath,
+            self._basepath,
+            self._version,
+        ) = self._discover_version_and_paths()
         self._wire_up_description()
         self._actions = {}
         self._views = {}

--- a/maas/client/flesh/tables.py
+++ b/maas/client/flesh/tables.py
@@ -155,6 +155,14 @@ class NodeResourcePoolColumn(Column):
         return super().render(target, data.name)
 
 
+class NodeTagsColumn(Column):
+    def render(self, target, data):
+        if data:
+            return super().render(target, ", ".join(tag.name for tag in data))
+        else:
+            return ""
+
+
 class NodesTable(Table):
     def __init__(self):
         super().__init__(
@@ -215,7 +223,7 @@ class MachineDetail(DetailTable):
             NodeResourcePoolColumn("pool", "Resource pool"),
             NodeZoneColumn("zone", "Zone"),
             NodeOwnerColumn("owner", "Owner"),
-            Column("tags", "Tags"),
+            NodeTagsColumn("tags", "Tags"),
         ]
         if with_type:
             columns.insert(1, NodeTypeColumn("node_type", "Type"))

--- a/maas/client/flesh/tables.py
+++ b/maas/client/flesh/tables.py
@@ -158,7 +158,7 @@ class NodeResourcePoolColumn(Column):
 class NodeTagsColumn(Column):
     def render(self, target, data):
         if data:
-            return super().render(target, ", ".join(tag.name for tag in data))
+            return super().render(target, [tag.name for tag in data])
         else:
             return ""
 

--- a/maas/client/flesh/tests/test_machines.py
+++ b/maas/client/flesh/tests/test_machines.py
@@ -131,7 +131,7 @@ class TestMachine(TestCaseWithProfile):
         cmd = machines.cmd_machine(parser)
         subparser = machines.cmd_machine.register(parser)
         options = subparser.parse_args([machine_objs[0]["hostname"]])
-        output = yaml.safe_load(
+        yaml_output = yaml.safe_load(
             cmd.execute(origin, options, target=tabular.RenderTarget.yaml)
         )
-        self.assertEqual(output.get("tags"), "tag1, tag2")
+        self.assertEqual(yaml_output.get("tags"), ["tag1", "tag2"])


### PR DESCRIPTION
Viscera layer produces a Tags.Managed object for machines with tags, this can't be simply str()ified.

Added a simple test for this behaviour, but there's a gap of testing for machine details in general.

Drive-by cleaned up a `yaml.load`

An example of how this looks for the plain renderer:
```
+---------------+-------------+
| Hostname      | name-wn44bg |
| Status        | READY       |
| Image         | (none)      |
| Power         | Off         |
| Power Type    | Manual      |
| Arch          | amd64       |
| #CPUs         | 2           |
| RAM           | 1.0 GB      |
| Interfaces    | 0 physical  |
| IP addresses  |             |
| Resource pool | pool1       |
| Zone          | zone1       |
| Owner         | (none)      |
| Tags          | tag1        |
|               | tag2        |
+---------------+-------------+
```