### PR TITLE
Added nodes.read endpoint so you can query by hostname to get the system_id indirectly

### DIFF
--- a/maas/client/facade.py
+++ b/maas/client/facade.py
@@ -186,6 +186,12 @@ class Client:
         }
 
     @facade
+    def nodes(origin):
+        return {
+            "read": origin.Nodes.read,
+        }
+
+    @facade
     def machines(origin):
         return {
             "allocate": origin.Machines.allocate,


### PR DESCRIPTION
The nodes endpoint is completely missing in facade.py  Added the nodes.read (thus client.nodes.read(hostnames=[])  This allows for querying maas by hostname QUICKLY which gets you the system_id which you can then query for full machine detail.  This a aworkaround due to clien.machines.read() only accepting a system_id argument unlike the maas Client API distributed with maas since at least 2.6.2 which supports querying on a wide variety of criteria see https://github.com/maas/python-libmaas/issues/238