### PR TITLE
Add read-only 'pod' property to Machine objects

### DIFF
--- a/maas/client/viscera/machines.py
+++ b/maas/client/viscera/machines.py
@@ -373,6 +373,7 @@ class Machine(Node, metaclass=MachineType):
     status_name = ObjectField.Checked("status_name", check(str), readonly=True)
     raids = ObjectFieldRelatedSet("raids", "Raids", reverse=None)
     volume_groups = ObjectFieldRelatedSet("volume_groups", "VolumeGroups", reverse=None)
+    pod = ObjectFieldRelated("pod", "Pod", readonly=True)
 
     async def save(self):
         """Save the machine in MAAS."""


### PR DESCRIPTION
This new property allows the client to know in which pod a virtual machine was commissioned (if any). Very useful for building dependency trees between machines.