### PR TITLE
Adds `delete` ssh key method

### DIFF
--- a/maas/client/viscera/sshkeys.py
+++ b/maas/client/viscera/sshkeys.py
@@ -23,7 +23,6 @@ class SSHKeysType(ObjectType):
         """
         return cls._object(await cls._handler.create(key=key))
 
-
 class SSHKeys(ObjectSet, metaclass=SSHKeysType):
     """The set of SSH keys stored in MAAS."""
 
@@ -41,3 +40,9 @@ class SSHKey(Object, metaclass=SSHKeyType):
     id = ObjectField.Checked("id", check(int), readonly=True)
     key = ObjectField.Checked("key", check(str), readonly=True)
     keysource = ObjectField.Checked("keysource", check_optional(str), readonly=True)
+
+    async def delete(self):
+        """Delete this key."""
+        await self._handler.delete(
+            id=self.id,
+        )

--- a/maas/client/viscera/sshkeys.py
+++ b/maas/client/viscera/sshkeys.py
@@ -23,6 +23,7 @@ class SSHKeysType(ObjectType):
         """
         return cls._object(await cls._handler.create(key=key))
 
+
 class SSHKeys(ObjectSet, metaclass=SSHKeysType):
     """The set of SSH keys stored in MAAS."""
 

--- a/maas/client/viscera/tests/test_sshkeys.py
+++ b/maas/client/viscera/tests/test_sshkeys.py
@@ -48,3 +48,11 @@ class TestSSHKey(TestCase):
         key_dict = {"id": key_id, "key": make_string_without_spaces(), "keysource": ""}
         SSHKey._handler.read.return_value = key_dict
         self.assertThat(SSHKey.read(id=key_id), Equals(SSHKey(key_dict)))
+
+    def test__sshkey_delete(self):
+        """ SSHKeys.read() returns a single SSH key. """
+        SSHKey = make_origin().SSHKey
+        key_id = random.randint(0, 100)
+        ssh_key = SSHKey({"id": key_id, "key": make_string_without_spaces(), "keysource": ""})
+        ssh_key.delete()
+        SSHKey._handler.delete.assert_called_once_with(id=key_id)

--- a/maas/client/viscera/tests/test_sshkeys.py
+++ b/maas/client/viscera/tests/test_sshkeys.py
@@ -50,9 +50,11 @@ class TestSSHKey(TestCase):
         self.assertThat(SSHKey.read(id=key_id), Equals(SSHKey(key_dict)))
 
     def test__sshkey_delete(self):
-        """ SSHKeys.read() returns a single SSH key. """
+        """SSHKeys.read() returns a single SSH key."""
         SSHKey = make_origin().SSHKey
         key_id = random.randint(0, 100)
-        ssh_key = SSHKey({"id": key_id, "key": make_string_without_spaces(), "keysource": ""})
+        ssh_key = SSHKey(
+            {"id": key_id, "key": make_string_without_spaces(), "keysource": ""}
+        )
         ssh_key.delete()
         SSHKey._handler.delete.assert_called_once_with(id=key_id)


### PR DESCRIPTION
Hi

We are using this method quite a lot to remove ssh keys from MAAS.

Meaning we are providing our users with the ability to work with a certain machine(s) using generated ssh key for some time.
And once time runs out we have to remove this key to prevent user access to the newly deployed OSes.

Thank you,
Costya