### PR TITLE
Fix Python 3.10 Collections package import error

### DIFF
--- a/maas/client/bones/__init__.py
+++ b/maas/client/bones/__init__.py
@@ -7,7 +7,13 @@ hence the name "bones".
 __all__ = ["CallError", "SessionAPI"]
 
 import typing
-from collections import Iterable, namedtuple
+try:
+    # Python <= 3.9
+    from collections import Iterable, namedtuple
+except:
+        # Python > 3.9
+    from collections import namedtuple
+    from collections.abc import Iterable
 import json
 from urllib.parse import urlparse
 

--- a/maas/client/utils/__init__.py
+++ b/maas/client/utils/__init__.py
@@ -26,7 +26,13 @@ __all__ = [
     "vars_class",
 ]
 
-from collections import Iterable, namedtuple
+try:
+    # Python <= 3.9
+    from collections import Iterable, namedtuple
+except:
+    # Python > 3.9
+    from collections import namedtuple
+    from collections.abc import Iterable
 from functools import lru_cache, partial
 from inspect import cleandoc, getdoc
 from itertools import chain, cycle, repeat

--- a/maas/client/utils/multipart.py
+++ b/maas/client/utils/multipart.py
@@ -16,7 +16,12 @@
 
 __all__ = ["encode_multipart_data"]
 
-from collections import Iterable, Mapping
+try:
+    # Python <= 3.9
+    from collections import Iterable,Mapping
+except:
+    # Python > 3.9
+    from collections.abc import Sequence
 from email.generator import BytesGenerator
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart

--- a/maas/client/viscera/__init__.py
+++ b/maas/client/viscera/__init__.py
@@ -19,7 +19,13 @@ __all__ = [
     "OriginBase",
 ]
 
-from collections import defaultdict, Iterable, Mapping, Sequence
+try:
+    # Python <= 3.9
+    from collections import defaultdict, Iterable, Mapping, Sequence
+except:
+    # Python > 3.9
+    from collections.abc import Iterable ,Mapping ,Sequence
+    from collections import defaultdict
 from copy import copy
 from datetime import datetime
 from functools import wraps

--- a/maas/client/viscera/boot_source_selections.py
+++ b/maas/client/viscera/boot_source_selections.py
@@ -2,7 +2,13 @@
 
 __all__ = ["BootSourceSelection", "BootSourceSelections"]
 
-from collections import Sequence
+try:
+    # Python <= 3.9
+    from collections import Sequence
+except:
+    # Python > 3.9
+    from collections.abc import Sequence
+
 
 from . import check, Object, ObjectField, ObjectFieldRelated, ObjectSet, ObjectType
 from .boot_sources import BootSource

--- a/maas/client/viscera/nodes.py
+++ b/maas/client/viscera/nodes.py
@@ -2,7 +2,13 @@
 
 __all__ = ["Node", "Nodes"]
 
-from collections import Sequence
+try:
+    # Python <= 3.9
+    from collections import Sequence
+except:
+    # Python > 3.9
+    from collections.abc import Sequence
+
 import typing
 
 from . import (

--- a/maas/client/viscera/testing/__init__.py
+++ b/maas/client/viscera/testing/__init__.py
@@ -2,7 +2,12 @@
 
 __all__ = ["bind"]
 
-from collections import Mapping
+try:
+    # Python <= 3.9
+    from collections import Mapping
+except:
+    # Python > 3.9
+    from collections.abc import Mapping
 from itertools import chain
 from unittest.mock import Mock
 


### PR DESCRIPTION
Fix Python > 3.9 collections import error, some library of it has moved to collections/abc.py, I try to keep this package update with the latest python changes.