### PR TITLE
prevent expand() iterating through string value #277

### DIFF
--- a/maas/client/bones/__init__.py
+++ b/maas/client/bones/__init__.py
@@ -417,7 +417,7 @@ class CallAPI:
 
         def expand(data):
             for name, value in data.items():
-                if isinstance(value, Iterable):
+                if isinstance(value, Iterable) and not isinstance(value, str):
                     for value in value:
                         yield name, value
                 else:


### PR DESCRIPTION
Fixes #277 

```
>>> session.MAAS.get_config(name="ntp_servers")
'ntp.ubuntu.com'
```